### PR TITLE
Get data from private channel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>fess-ds-slack</artifactId>
 	<packaging>jar</packaging>
 	<name>Slack Data Store</name>
-	<version>13.3.0</version>
+	<version>13.3.1-SNAPSHOT</version>
 	<url>https://fess.codelibs.org/</url>
 	<inceptionYear>2009</inceptionYear>
 	<licenses>


### PR DESCRIPTION
This plugin cannot crawl data from private channel because Slack's `conversations.list` API consider public channel by default argument in `types`.  [This is a API page.](https://api.slack.com/methods/conversations.list)

Therefore, I add new setter section about `types`.  This allows FESS to crawl not only public channels but also private ones.