### PR TITLE
Get channel list from private channel

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/slack/SlackDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/SlackDataStore.java
@@ -105,7 +105,7 @@ public class SlackDataStore extends AbstractDataStore {
     }
 
     protected void initChannelsMap(final SlackClient client) {
-        ConversationsListResponse response = client.conversations.list().limit(100).execute();
+        ConversationsListResponse response = client.conversations.list().types("public_channel,private_channel").limit(100).execute();
         while (true) {
             if (!response.ok()) {
                 logger.warn("Slack API error occured on \"conversations.list\": " + response.getError());
@@ -119,7 +119,7 @@ public class SlackDataStore extends AbstractDataStore {
             if (nextCursor.isEmpty()) {
                 break;
             }
-            response = client.conversations.list().limit(100).cursor(nextCursor).execute();
+            response = client.conversations.list().types("public_channel,private_channel").limit(100).cursor(nextCursor).execute();
         }
     }
 


### PR DESCRIPTION
The current implementation cannot crawl data from private channel because Slack's `conversations.list` API returns only public channel by default argument in `types`.  [Reference: Slack's API page](https://api.slack.com/methods/conversations.list)

Therefore, I add new setter section about `types`.  This allows FESS to crawl not only public channels but also private ones.