### PR TITLE
Add JavaDoc comments to Slack data store and API classes

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/slack/SlackClient.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/SlackClient.java
@@ -55,40 +55,87 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
+/**
+ * Slack Web API client that provides high-level access to Slack data including
+ * teams, channels, users, messages, and files. This client manages authentication,
+ * caching, and rate limiting for efficient access to the Slack API.
+ *
+ * <p>Key features:</p>
+ * <ul>
+ * <li>Authentication with OAuth tokens</li>
+ * <li>Caching of users, bots, and channels for performance</li>
+ * <li>Support for both public and private channels</li>
+ * <li>Pagination handling for large datasets</li>
+ * <li>Proxy support for network configurations</li>
+ * </ul>
+ */
 public class SlackClient implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(SlackClient.class);
 
+    /** Parameter name for the OAuth access token. */
     protected static final String TOKEN_PARAM = "token";
+    /** Parameter name for including private channels. */
     protected static final String INCLUDE_PRIVATE_PARAM = "include_private";
+    /** Parameter name for specifying channels to crawl. */
     protected static final String CHANNELS_PARAM = "channels";
+    /** Special value to indicate all channels should be crawled. */
     protected static final String CHANNELS_ALL = "*all";
+    /** Separator for multiple channel names. */
     protected static final String CHANNELS_SEPARATOR = ",";
+    /** Parameter name for channel pagination limit. */
     protected static final String CHANNEL_COUNT_PARAM = "channel_count";
+    /** Parameter name for user pagination limit. */
     protected static final String USER_COUNT_PARAM = "user_count";
+    /** Parameter name for message pagination limit. */
     protected static final String MESSAGE_COUNT_PARAM = "message_count";
+    /** Parameter name for file pagination limit. */
     protected static final String FILE_COUNT_PARAM = "file_count";
+    /** Parameter name for proxy host configuration. */
     protected static final String PROXY_HOST_PARAM = "proxy_host";
+    /** Parameter name for proxy port configuration. */
     protected static final String PROXY_PORT_PARAM = "proxy_port";
+    /** Parameter name for file type filtering. */
     protected static final String FILE_TYPES_PARAM = "file_types";
 
+    /** Parameter name for user cache size configuration. */
     protected static final String USER_CACHE_SIZE_PARAM = "user_cache_size";
+    /** Parameter name for bot cache size configuration. */
     protected static final String BOT_CACHE_SIZE_PARAM = "bot_cache_size";
+    /** Parameter name for channel cache size configuration. */
     protected static final String CHANNEL_CACHE_SIZE_PARAM = "channel_cache_size";
 
+    /** Default pagination limit for channels. */
     protected static final String DEFAULT_CHANNEL_COUNT = "100";
+    /** Default pagination limit for users. */
     protected static final String DEFAULT_USER_COUNT = "100";
+    /** Default pagination limit for messages. */
     protected static final String DEFAULT_MESSAGE_COUNT = "100";
+    /** Default pagination limit for files. */
     protected static final String DEFAULT_FILE_COUNT = "20";
+    /** Default cache size for all caches. */
     protected static final String DEFAULT_CACHE_SIZE = "10000";
 
+    /** Whether to include private channels in operations. */
     protected final Boolean includePrivate;
+    /** Authentication credentials for Slack API access. */
     protected final Authentication authentication;
+    /** Configuration parameters for the data store. */
     protected DataStoreParams paramMap;
+    /** Cache for user information to improve performance. */
     protected LoadingCache<String, User> usersCache;
+    /** Cache for bot information to improve performance. */
     protected LoadingCache<String, Bot> botsCache;
+    /** Cache for channel information to improve performance. */
     protected LoadingCache<String, Channel> channelsCache;
 
+    /**
+     * Creates a new Slack client with the specified configuration parameters.
+     * Initializes authentication, proxy settings, and caches for improved performance.
+     *
+     * @param paramMap the configuration parameters including token, proxy settings, and cache sizes
+     * @throws SlackDataStoreException if required parameters are missing or invalid
+     */
     public SlackClient(final DataStoreParams paramMap) {
         final String token = getToken(paramMap);
 
@@ -148,46 +195,109 @@ public class SlackClient implements Closeable {
         });
     }
 
+    /**
+     * Creates a bots.info API request builder.
+     *
+     * @return a new BotsInfoRequest instance
+     */
     public BotsInfoRequest botsInfo() {
         return new BotsInfoRequest(authentication);
     }
 
+    /**
+     * Creates a chat.getPermalink API request builder.
+     *
+     * @param channel the channel ID or name
+     * @param ts the message timestamp
+     * @return a new ChatGetPermalinkRequest instance
+     */
     public ChatGetPermalinkRequest chatGetPermalink(final String channel, final String ts) {
         return new ChatGetPermalinkRequest(authentication, channel, ts);
     }
 
+    /**
+     * Creates a conversations.list API request builder.
+     *
+     * @return a new ConversationsListRequest instance
+     */
     public ConversationsListRequest conversationsList() {
         return new ConversationsListRequest(authentication);
     }
 
+    /**
+     * Creates a conversations.history API request builder.
+     *
+     * @param channel the channel ID or name
+     * @return a new ConversationsHistoryRequest instance
+     */
     public ConversationsHistoryRequest conversationsHistory(final String channel) {
         return new ConversationsHistoryRequest(authentication, channel);
     }
 
+    /**
+     * Creates a conversations.info API request builder.
+     *
+     * @param channel the channel ID or name
+     * @return a new ConversationsInfoRequest instance
+     */
     public ConversationsInfoRequest conversationsInfo(final String channel) {
         return new ConversationsInfoRequest(authentication, channel);
     }
 
+    /**
+     * Creates a conversations.replies API request builder.
+     *
+     * @param channel the channel ID or name
+     * @param ts the message timestamp
+     * @return a new ConversationsRepliesRequest instance
+     */
     public ConversationsRepliesRequest conversationsReplies(final String channel, final String ts) {
         return new ConversationsRepliesRequest(authentication, channel, ts);
     }
 
+    /**
+     * Creates a files.list API request builder.
+     *
+     * @return a new FilesListRequest instance
+     */
     public FilesListRequest filesList() {
         return new FilesListRequest(authentication);
     }
 
+    /**
+     * Creates a files.info API request builder.
+     *
+     * @param file the file ID
+     * @return a new FilesInfoRequest instance
+     */
     public FilesInfoRequest filesInfo(final String file) {
         return new FilesInfoRequest(authentication, file);
     }
 
+    /**
+     * Creates a team.info API request builder.
+     *
+     * @return a new TeamInfoRequest instance
+     */
     public TeamInfoRequest teamInfo() {
         return new TeamInfoRequest(authentication);
     }
 
+    /**
+     * Creates a users.list API request builder.
+     *
+     * @return a new UsersListRequest instance
+     */
     public UsersListRequest usersList() {
         return new UsersListRequest(authentication);
     }
 
+    /**
+     * Creates a users.info API request builder.
+     *
+     * @param user the user ID or username
+     * @return a new UsersInfoRequest instance
+     */
     public UsersInfoRequest usersInfo(final String user) {
         return new UsersInfoRequest(authentication, user);
     }
@@ -200,55 +310,133 @@ public class SlackClient implements Closeable {
         channelsCache.invalidateAll();
     }
 
+    /**
+     * Extracts the OAuth access token from the configuration parameters.
+     *
+     * @param paramMap the configuration parameters
+     * @return the OAuth access token or empty string if not found
+     */
     protected String getToken(final DataStoreParams paramMap) {
         return paramMap.getAsString(TOKEN_PARAM, StringUtil.EMPTY);
     }
 
+    /**
+     * Determines whether private channels should be included in operations.
+     *
+     * @param paramMap the configuration parameters
+     * @return true if private channels should be included, false otherwise
+     */
     protected Boolean isIncludePrivate(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(INCLUDE_PRIVATE_PARAM, Constants.FALSE));
     }
 
+    /**
+     * Extracts the proxy host from the configuration parameters.
+     *
+     * @param paramMap the configuration parameters
+     * @return the proxy host or empty string if not configured
+     */
     protected String getProxyHost(final DataStoreParams paramMap) {
         return paramMap.getAsString(PROXY_HOST_PARAM, StringUtil.EMPTY);
     }
 
+    /**
+     * Extracts the proxy port from the configuration parameters.
+     *
+     * @param paramMap the configuration parameters
+     * @return the proxy port or empty string if not configured
+     */
     protected String getProxyPort(final DataStoreParams paramMap) {
         return paramMap.getAsString(PROXY_PORT_PARAM, StringUtil.EMPTY);
     }
 
+    /**
+     * Returns the channel types to include based on configuration.
+     *
+     * @return comma-separated list of channel types to include
+     */
     protected String getTypes() {
         return includePrivate ? "public_channel,private_channel" : "public_channel";
     }
 
+    /**
+     * Returns the file types to include when crawling files.
+     *
+     * @return comma-separated list of file types or "all" for all types
+     */
     protected String getFileTypes() {
         return paramMap.getAsString(FILE_TYPES_PARAM, "all");
     }
 
+    /**
+     * Retrieves information about the current team.
+     *
+     * @return the team information
+     */
     public Team getTeam() {
         return teamInfo().execute().getTeam();
     }
 
+    /**
+     * Retrieves bot information by bot name, using cache for performance.
+     *
+     * @param botName the bot name or ID
+     * @return the bot information
+     * @throws ExecutionException if the bot information cannot be retrieved
+     */
     public Bot getBot(final String botName) throws ExecutionException {
         return botsCache.get(botName);
     }
 
+    /**
+     * Retrieves user information by username, using cache for performance.
+     *
+     * @param userName the username or user ID
+     * @return the user information
+     * @throws ExecutionException if the user information cannot be retrieved
+     */
     public User getUser(final String userName) throws ExecutionException {
         return usersCache.get(userName);
     }
 
+    /**
+     * Retrieves channel information by channel name, using cache for performance.
+     *
+     * @param channelName the channel name or ID
+     * @return the channel information
+     * @throws ExecutionException if the channel information cannot be retrieved
+     */
     public Channel getChannel(final String channelName) throws ExecutionException {
         return channelsCache.get(channelName);
     }
 
+    /**
+     * Retrieves the permalink URL for a specific message.
+     *
+     * @param channelId the channel ID
+     * @param threadTs the message timestamp
+     * @return the permalink URL for the message
+     */
     public String getPermalink(final String channelId, final String threadTs) {
         return chatGetPermalink(channelId, threadTs).execute().getPermalink();
     }
 
+    /**
+     * Downloads a file from Slack using authenticated HTTP request.
+     *
+     * @param fileUrl the URL of the file to download
+     * @return the HTTP response containing the file content
+     */
     public CurlResponse getFileResponse(final String fileUrl) {
         return Curl.get(fileUrl).header("Authorization", "Bearer " + getToken(paramMap))
                 .header("Content-type", "application/x-www-form-urlencoded ").execute();
     }
 
+    /**
+     * Processes channels based on configuration, either all channels or specific ones.
+     *
+     * @param consumer the function to process each channel
+     */
     public void getChannels(final Consumer<Channel> consumer) {
         if (!paramMap.containsKey(CHANNELS_PARAM) || CHANNELS_ALL.equals(paramMap.get(CHANNELS_PARAM))) {
             getAllChannels(consumer);
@@ -263,10 +451,23 @@ public class SlackClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all files from a specific channel using default pagination.
+     *
+     * @param channelId the channel ID
+     * @param consumer the function to process each file
+     */
     public void getChannelFiles(final String channelId, final Consumer<File> consumer) {
         getChannelFiles(channelId, Integer.parseInt(paramMap.getAsString(FILE_COUNT_PARAM, DEFAULT_FILE_COUNT)), consumer);
     }
 
+    /**
+     * Retrieves files from a specific channel with custom pagination.
+     *
+     * @param channelId the channel ID
+     * @param count the number of files to retrieve per page
+     * @param consumer the function to process each file
+     */
     public void getChannelFiles(final String channelId, final Integer count, final Consumer<File> consumer) {
         FilesListResponse response = filesList().channel(channelId).types(getFileTypes()).count(count).execute();
         while (true) {
@@ -282,10 +483,21 @@ public class SlackClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all channels using default pagination.
+     *
+     * @param consumer the function to process each channel
+     */
     public void getAllChannels(final Consumer<Channel> consumer) {
         getAllChannels(Integer.parseInt(paramMap.getAsString(CHANNEL_COUNT_PARAM, DEFAULT_CHANNEL_COUNT)), consumer);
     }
 
+    /**
+     * Retrieves all channels with custom pagination limit.
+     *
+     * @param limit the maximum number of channels to retrieve per page
+     * @param consumer the function to process each channel
+     */
     public void getAllChannels(final Integer limit, final Consumer<Channel> consumer) {
         ConversationsListResponse response = conversationsList().types(getTypes()).limit(limit).execute();
         while (true) {
@@ -302,10 +514,23 @@ public class SlackClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all messages from a specific channel using default pagination.
+     *
+     * @param channelId the channel ID
+     * @param consumer the function to process each message
+     */
     public void getChannelMessages(final String channelId, final Consumer<Message> consumer) {
         getChannelMessages(channelId, Integer.parseInt(paramMap.getAsString(MESSAGE_COUNT_PARAM, DEFAULT_MESSAGE_COUNT)), consumer);
     }
 
+    /**
+     * Retrieves messages from a specific channel with custom pagination limit.
+     *
+     * @param channelId the channel ID
+     * @param limit the maximum number of messages to retrieve per page
+     * @param consumer the function to process each message
+     */
     public void getChannelMessages(final String channelId, final Integer limit, final Consumer<Message> consumer) {
         ConversationsHistoryResponse response = conversationsHistory(channelId).limit(limit).execute();
         while (true) {
@@ -321,11 +546,26 @@ public class SlackClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all replies to a threaded message using default pagination.
+     *
+     * @param channelId the channel ID
+     * @param threadTs the thread timestamp
+     * @param consumer the function to process each reply message
+     */
     public void getMessageReplies(final String channelId, final String threadTs, final Consumer<Message> consumer) {
         getMessageReplies(channelId, threadTs, Integer.parseInt(paramMap.getAsString(MESSAGE_COUNT_PARAM, DEFAULT_MESSAGE_COUNT)),
                 consumer);
     }
 
+    /**
+     * Retrieves replies to a threaded message with custom pagination limit.
+     *
+     * @param channelId the channel ID
+     * @param threadTs the thread timestamp
+     * @param limit the maximum number of replies to retrieve per page
+     * @param consumer the function to process each reply message
+     */
     public void getMessageReplies(final String channelId, final String threadTs, final Integer limit, final Consumer<Message> consumer) {
         ConversationsRepliesResponse response = conversationsReplies(channelId, threadTs).limit(limit).execute();
         while (true) {
@@ -349,10 +589,21 @@ public class SlackClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all users using default pagination.
+     *
+     * @param consumer the function to process each user
+     */
     public void getUsers(final Consumer<User> consumer) {
         getUsers(Integer.parseInt(paramMap.getAsString(USER_COUNT_PARAM, DEFAULT_USER_COUNT)), consumer);
     }
 
+    /**
+     * Retrieves all users with custom pagination limit.
+     *
+     * @param limit the maximum number of users to retrieve per page
+     * @param consumer the function to process each user
+     */
     public void getUsers(final Integer limit, final Consumer<User> consumer) {
         UsersListResponse response = usersList().limit(limit).execute();
         while (true) {

--- a/src/main/java/org/codelibs/fess/ds/slack/SlackDataStoreException.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/SlackDataStoreException.java
@@ -17,18 +17,38 @@ package org.codelibs.fess.ds.slack;
 
 import org.codelibs.fess.exception.DataStoreException;
 
+/**
+ * Exception thrown when errors occur during Slack data store operations.
+ * This includes API authentication failures, network issues, and data processing errors.
+ */
 public class SlackDataStoreException extends DataStoreException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new exception with the specified message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause of this exception
+     */
     public SlackDataStoreException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Creates a new exception with the specified message.
+     *
+     * @param message the detail message
+     */
     public SlackDataStoreException(final String message) {
         super(message);
     }
 
+    /**
+     * Creates a new exception with the specified cause.
+     *
+     * @param cause the cause of this exception
+     */
     public SlackDataStoreException(final Throwable cause) {
         super(cause);
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/Authentication.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/Authentication.java
@@ -18,24 +18,50 @@ package org.codelibs.fess.ds.slack.api;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 
+/**
+ * Handles authentication for Slack API requests including OAuth tokens and proxy configuration.
+ */
 public class Authentication {
 
+    /** OAuth access token for Slack API authentication. */
     protected String token;
 
+    /** HTTP proxy configuration for API requests. */
     protected Proxy httpProxy;
 
+    /**
+     * Creates a new Authentication instance with the specified OAuth token.
+     *
+     * @param token the OAuth access token for Slack API
+     */
     public Authentication(final String token) {
         this.token = token;
     }
 
+    /**
+     * Returns the OAuth access token.
+     *
+     * @return the OAuth access token
+     */
     public String getToken() {
         return token;
     }
 
+    /**
+     * Configures an HTTP proxy for API requests.
+     *
+     * @param httpProxyHost the proxy host
+     * @param httpProxyPort the proxy port
+     */
     public void setHttpProxy(final String httpProxyHost, final Integer httpProxyPort) {
         this.httpProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(httpProxyHost, httpProxyPort));
     }
 
+    /**
+     * Returns the configured HTTP proxy.
+     *
+     * @return the HTTP proxy, or null if not configured
+     */
     public Proxy getHttpProxy() {
         return httpProxy;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/Request.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/Request.java
@@ -25,24 +25,57 @@ import org.codelibs.fess.ds.slack.SlackDataStoreException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * Abstract base class for all Slack API requests.
+ * Provides common functionality for authentication, HTTP request building,
+ * and response parsing for Slack Web API calls.
+ *
+ * @param <T> the response type that this request will return
+ */
 public abstract class Request<T extends Response> {
 
+    /** Function for creating GET HTTP requests */
     public static final Function<String, CurlRequest> GET = Curl::get;
+    /** Function for creating POST HTTP requests */
     public static final Function<String, CurlRequest> POST = Curl::post;
+    /** Function for creating PUT HTTP requests */
     public static final Function<String, CurlRequest> PUT = Curl::put;
+    /** Function for creating DELETE HTTP requests */
     public static final Function<String, CurlRequest> DELETE = Curl::delete;
 
+    /** Base URL for all Slack API endpoints */
     protected static final String SLACK_API_ENDPOINT = "https://slack.com/api/";
+    /** Jackson ObjectMapper for JSON parsing */
     protected static final ObjectMapper mapper = new ObjectMapper();
 
+    /** Authentication credentials for Slack API access */
     protected Authentication authentication;
 
+    /**
+     * Constructs a new request with the specified authentication credentials.
+     *
+     * @param authentication the authentication credentials for Slack API access
+     */
     public Request(final Authentication authentication) {
         this.authentication = authentication;
     }
 
+    /**
+     * Executes this request and returns the parsed response.
+     * Subclasses must implement this method to define the specific API call behavior.
+     *
+     * @return the parsed response from the Slack API
+     */
     public abstract T execute();
 
+    /**
+     * Parses the raw JSON response content into the specified response type.
+     *
+     * @param content the raw JSON response content from the API
+     * @param valueType the class type to parse the response into
+     * @return the parsed response object
+     * @throws SlackDataStoreException if JSON parsing fails
+     */
     public T parseResponse(final String content, final Class<T> valueType) {
         try {
             return mapper.readValue(content, valueType).responseBody(content);
@@ -51,6 +84,14 @@ public abstract class Request<T extends Response> {
         }
     }
 
+    /**
+     * Creates a configured HTTP request for the specified API method and path.
+     * Automatically adds authentication headers and proxy configuration.
+     *
+     * @param method the HTTP method function (GET, POST, PUT, DELETE)
+     * @param path the API endpoint path to append to the base URL
+     * @return a configured CurlRequest ready for execution
+     */
     public CurlRequest getCurlRequest(final Function<String, CurlRequest> method, final String path) {
         final StringBuilder buf = new StringBuilder(100);
         buf.append(SLACK_API_ENDPOINT);

--- a/src/main/java/org/codelibs/fess/ds/slack/api/Response.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/Response.java
@@ -18,29 +18,68 @@ package org.codelibs.fess.ds.slack.api;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Abstract base class for all Slack API responses providing common response handling.
+ */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public abstract class Response {
 
+    /**
+     * Default constructor.
+     */
+    public Response() {
+    }
+
+    /** Whether the API request was successful. */
     protected Boolean ok;
+    /** Error message if the request failed. */
     protected String error;
+    /** Raw response body from the API. */
     protected String responseBody;
 
+    /**
+     * Returns whether the API request was successful.
+     *
+     * @return true if successful, false otherwise
+     */
     public boolean ok() {
         return ok == null ? false : ok;
     }
 
+    /**
+     * Returns the success status of the API request.
+     *
+     * @return the success status Boolean
+     */
     public Boolean getOk() {
         return ok;
     }
 
+    /**
+     * Returns the error message if the request failed.
+     *
+     * @return the error message, or null if no error
+     */
     public String getError() {
         return error;
     }
 
+    /**
+     * Returns the raw response body from the API.
+     *
+     * @return the response body
+     */
     public String responseBody() {
         return responseBody;
     }
 
+    /**
+     * Sets the raw response body and returns this response instance.
+     *
+     * @param responseBody the response body to set
+     * @param <T> the specific response type
+     * @return this response instance for method chaining
+     */
     public <T extends Response> T responseBody(final String responseBody) {
         this.responseBody = responseBody;
         return (T) this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/bots/BotsInfoRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/bots/BotsInfoRequest.java
@@ -19,10 +19,19 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request to retrieve information about a specific bot in Slack.
+ */
 public class BotsInfoRequest extends Request<BotsInfoResponse> {
 
+    /** The bot ID to retrieve information for. */
     protected String bot;
 
+    /**
+     * Creates a new bots.info request with the specified authentication.
+     *
+     * @param authenctication the authentication credentials
+     */
     public BotsInfoRequest(final Authentication authenctication) {
         super(authenctication);
     }
@@ -32,6 +41,12 @@ public class BotsInfoRequest extends Request<BotsInfoResponse> {
         return parseResponse(request().execute().getContentAsString(), BotsInfoResponse.class);
     }
 
+    /**
+     * Sets the bot ID to retrieve information for.
+     *
+     * @param bot the bot ID
+     * @return this request instance for method chaining
+     */
     public BotsInfoRequest bot(final String bot) {
         this.bot = bot;
         return this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/bots/BotsInfoResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/bots/BotsInfoResponse.java
@@ -22,12 +22,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response from the bots.info API method containing bot information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BotsInfoResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public BotsInfoResponse() {
+        super();
+    }
+
+    /** The bot information returned by the API. */
     protected Bot bot;
 
+    /**
+     * Returns the bot information.
+     *
+     * @return the bot details
+     */
     public Bot getBot() {
         return bot;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/chat/ChatGetPermalinkRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/chat/ChatGetPermalinkRequest.java
@@ -19,11 +19,23 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request to retrieve a permalink URL for a specific message in Slack.
+ */
 public class ChatGetPermalinkRequest extends Request<ChatGetPermalinkResponse> {
 
+    /** The channel ID containing the message. */
     protected final String channel;
+    /** The timestamp of the message. */
     protected final String ts;
 
+    /**
+     * Creates a new chat.getPermalink request.
+     *
+     * @param authentication the authentication credentials
+     * @param channel the channel ID
+     * @param ts the message timestamp
+     */
     public ChatGetPermalinkRequest(final Authentication authentication, final String channel, final String ts) {
         super(authentication);
         this.channel = channel;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/chat/ChatGetPermalinkResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/chat/ChatGetPermalinkResponse.java
@@ -21,17 +21,39 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response from the chat.getPermalink API method containing the permalink URL.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ChatGetPermalinkResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public ChatGetPermalinkResponse() {
+        super();
+    }
+
+    /** The channel ID where the message is located. */
     protected String channel;
+    /** The permalink URL for the message. */
     protected String permalink;
 
+    /**
+     * Returns the channel ID.
+     *
+     * @return the channel ID
+     */
     public String getChannel() {
         return channel;
     }
 
+    /**
+     * Returns the permalink URL for the message.
+     *
+     * @return the permalink URL
+     */
     public String getPermalink() {
         return permalink;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsHistoryRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsHistoryRequest.java
@@ -19,48 +19,107 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request class for retrieving conversation history from a Slack channel.
+ * Implements the conversations.history Slack Web API method to fetch messages
+ * from a specific channel with optional filtering and pagination parameters.
+ */
 public class ConversationsHistoryRequest extends Request<ConversationsHistoryResponse> {
 
+    /** The channel ID to retrieve history from */
     protected final String channel;
-    protected String cursor, latest, oldest;
+    /** Pagination cursor for fetching next page of results */
+    protected String cursor;
+    /** End of time range of messages to include in results (Unix timestamp) */
+    protected String latest;
+    /** Start of time range of messages to include in results (Unix timestamp) */
+    protected String oldest;
+    /** Maximum number of messages to return (default: 100, max: 1000) */
     protected Integer limit;
+    /** Include messages with latest or oldest timestamp in results */
     protected Boolean inclusive;
 
+    /**
+     * Constructs a new conversations history request.
+     *
+     * @param authentication the authentication credentials for API access
+     * @param channel the channel ID to retrieve history from
+     */
     public ConversationsHistoryRequest(final Authentication authentication, final String channel) {
         super(authentication);
         this.channel = channel;
     }
 
+    /**
+     * Executes the conversations.history API request.
+     *
+     * @return the response containing message history and pagination metadata
+     */
     @Override
     public ConversationsHistoryResponse execute() {
         return parseResponse(request().execute().getContentAsString(), ConversationsHistoryResponse.class);
     }
 
+    /**
+     * Sets the pagination cursor for retrieving the next page of results.
+     *
+     * @param cursor the pagination cursor from a previous response
+     * @return this request instance for method chaining
+     */
     public ConversationsHistoryRequest cursor(final String cursor) {
         this.cursor = cursor;
         return this;
     }
 
+    /**
+     * Sets whether to include messages with latest or oldest timestamp in results.
+     *
+     * @param inclusive true to include boundary timestamps, false to exclude them
+     * @return this request instance for method chaining
+     */
     public ConversationsHistoryRequest inclusive(final Boolean inclusive) {
         this.inclusive = inclusive;
         return this;
     }
 
+    /**
+     * Sets the end of time range of messages to include (Unix timestamp).
+     *
+     * @param latest the latest timestamp to include in results
+     * @return this request instance for method chaining
+     */
     public ConversationsHistoryRequest latest(final String latest) {
         this.latest = latest;
         return this;
     }
 
+    /**
+     * Sets the maximum number of messages to return per page.
+     *
+     * @param limit maximum number of messages (1-1000, default: 100)
+     * @return this request instance for method chaining
+     */
     public ConversationsHistoryRequest limit(final Integer limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Sets the start of time range of messages to include (Unix timestamp).
+     *
+     * @param oldest the oldest timestamp to include in results
+     * @return this request instance for method chaining
+     */
     public ConversationsHistoryRequest oldest(final String oldest) {
         this.oldest = oldest;
         return this;
     }
 
+    /**
+     * Builds the HTTP request with all configured parameters.
+     *
+     * @return the configured HTTP request
+     */
     private CurlRequest request() {
         final CurlRequest request = getCurlRequest(GET, "conversations.history");
         if (channel != null) {

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsHistoryResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsHistoryResponse.java
@@ -25,26 +25,60 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response class for the conversations.history Slack Web API method.
+ * Contains the list of messages from a channel along with pagination metadata.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ConversationsHistoryResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public ConversationsHistoryResponse() {
+        super();
+    }
+
+    /** List of messages retrieved from the channel */
     protected List<Message> messages;
+    /** Metadata for pagination including next cursor */
     protected ResponseMetadata responseMetadata;
+    /** Indicates if more messages are available for pagination */
     protected Boolean hasMore;
 
+    /**
+     * Gets the list of messages retrieved from the channel.
+     *
+     * @return list of messages, may be null if no messages found
+     */
     public List<Message> getMessages() {
         return messages;
     }
 
+    /**
+     * Gets the pagination metadata including next cursor.
+     *
+     * @return response metadata for pagination, may be null
+     */
     public ResponseMetadata getResponseMetadata() {
         return responseMetadata;
     }
 
+    /**
+     * Gets the raw hasMore flag indicating if more messages are available.
+     *
+     * @return Boolean indicating more messages availability, may be null
+     */
     public Boolean getHasMore() {
         return hasMore;
     }
 
+    /**
+     * Checks if more messages are available for pagination.
+     *
+     * @return true if more messages are available, false otherwise
+     */
     public boolean hasMore() {
         return hasMore == null ? false : hasMore;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsInfoRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsInfoRequest.java
@@ -19,26 +19,55 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request class for retrieving information about a Slack channel.
+ * Implements the conversations.info Slack Web API method to get
+ * detailed channel information including name, purpose, and settings.
+ */
 public class ConversationsInfoRequest extends Request<ConversationsInfoResponse> {
 
+    /** The channel ID to retrieve information for */
     protected final String channel;
+    /** Whether to include locale information in the response */
     protected Boolean includeLocale;
 
+    /**
+     * Constructs a new conversations info request.
+     *
+     * @param authentication the authentication credentials for API access
+     * @param channel the channel ID to retrieve information for
+     */
     public ConversationsInfoRequest(final Authentication authentication, final String channel) {
         super(authentication);
         this.channel = channel;
     }
 
+    /**
+     * Executes the conversations.info API request.
+     *
+     * @return the response containing detailed channel information
+     */
     @Override
     public ConversationsInfoResponse execute() {
         return parseResponse(request().execute().getContentAsString(), ConversationsInfoResponse.class);
     }
 
+    /**
+     * Sets whether to include locale information in the response.
+     *
+     * @param includeLocale true to include locale data, false to exclude it
+     * @return this request instance for method chaining
+     */
     public ConversationsInfoRequest includeLocale(final Boolean includeLocale) {
         this.includeLocale = includeLocale;
         return this;
     }
 
+    /**
+     * Builds the HTTP request with all configured parameters.
+     *
+     * @return the configured HTTP request
+     */
     private CurlRequest request() {
         final CurlRequest request = getCurlRequest(GET, "conversations.info");
         if (channel != null) {

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsInfoResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsInfoResponse.java
@@ -22,12 +22,30 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response class for the conversations.info Slack Web API method.
+ * Contains detailed information about a specific Slack channel including
+ * its name, purpose, settings, and metadata.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ConversationsInfoResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public ConversationsInfoResponse() {
+        super();
+    }
+
+    /** The channel information retrieved from the API */
     protected Channel channel;
 
+    /**
+     * Gets the detailed channel information.
+     *
+     * @return the channel object containing all channel details, may be null
+     */
     public Channel getChannel() {
         return channel;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsListRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsListRequest.java
@@ -19,41 +19,91 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request class for listing Slack channels.
+ * Implements the conversations.list Slack Web API method to retrieve
+ * all channels that the authenticated user has access to, with optional
+ * filtering and pagination parameters.
+ */
 public class ConversationsListRequest extends Request<ConversationsListResponse> {
 
-    protected String cursor, types;
+    /** Pagination cursor for fetching next page of results */
+    protected String cursor;
+    /** Comma-separated list of channel types to include (e.g., "public_channel,private_channel") */
+    protected String types;
+    /** Whether to exclude archived channels from results */
     protected Boolean excludeArchived;
+    /** Maximum number of channels to return (default: 100, max: 1000) */
     protected Integer limit;
 
+    /**
+     * Constructs a new conversations list request.
+     *
+     * @param authentication the authentication credentials for API access
+     */
     public ConversationsListRequest(final Authentication authentication) {
         super(authentication);
     }
 
+    /**
+     * Executes the conversations.list API request.
+     *
+     * @return the response containing list of channels and pagination metadata
+     */
     @Override
     public ConversationsListResponse execute() {
         return parseResponse(request().execute().getContentAsString(), ConversationsListResponse.class);
     }
 
+    /**
+     * Sets the pagination cursor for retrieving the next page of results.
+     *
+     * @param cursor the pagination cursor from a previous response
+     * @return this request instance for method chaining
+     */
     public ConversationsListRequest cursor(final String cursor) {
         this.cursor = cursor;
         return this;
     }
 
+    /**
+     * Sets whether to exclude archived channels from the results.
+     *
+     * @param excludeArchived true to exclude archived channels, false to include them
+     * @return this request instance for method chaining
+     */
     public ConversationsListRequest excludeArchived(final Boolean excludeArchived) {
         this.excludeArchived = excludeArchived;
         return this;
     }
 
+    /**
+     * Sets the types of channels to include in the results.
+     *
+     * @param types comma-separated list of channel types (e.g., "public_channel,private_channel")
+     * @return this request instance for method chaining
+     */
     public ConversationsListRequest types(final String types) {
         this.types = types;
         return this;
     }
 
+    /**
+     * Sets the maximum number of channels to return per page.
+     *
+     * @param limit maximum number of channels (1-1000, default: 100)
+     * @return this request instance for method chaining
+     */
     public ConversationsListRequest limit(final Integer limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Builds the HTTP request with all configured parameters.
+     *
+     * @return the configured HTTP request
+     */
     private CurlRequest request() {
         final CurlRequest request = getCurlRequest(GET, "conversations.list");
         if (cursor != null) {

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsListResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsListResponse.java
@@ -25,17 +25,41 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response class for the conversations.list API method.
+ * Contains a list of channels and pagination metadata.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ConversationsListResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public ConversationsListResponse() {
+        super();
+    }
+
+    /** List of channels returned by the API */
     protected List<Channel> channels;
+
+    /** Metadata for pagination and response handling */
     protected ResponseMetadata responseMetadata;
 
+    /**
+     * Gets the list of channels.
+     *
+     * @return the list of channels
+     */
     public List<Channel> getChannels() {
         return channels;
     }
 
+    /**
+     * Gets the response metadata for pagination.
+     *
+     * @return the response metadata
+     */
     public ResponseMetadata getResponseMetadata() {
         return responseMetadata;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsRepliesRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsRepliesRequest.java
@@ -19,44 +19,106 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request class for the conversations.replies API method.
+ * Retrieves thread replies for a specific message in a channel.
+ */
 public class ConversationsRepliesRequest extends Request<ConversationsRepliesResponse> {
 
-    protected final String channel, ts;
-    protected String cursor, latest, oldest;
+    /** Channel ID containing the thread */
+    protected final String channel;
+
+    /** Timestamp of the parent message */
+    protected final String ts;
+
+    /** Pagination cursor for retrieving more results */
+    protected String cursor;
+
+    /** Latest timestamp to include in results */
+    protected String latest;
+
+    /** Oldest timestamp to include in results */
+    protected String oldest;
+
+    /** Maximum number of messages to return */
     protected Integer limit;
+
+    /** Whether to include messages with timestamps matching boundaries */
     protected Boolean inclusive;
 
+    /**
+     * Constructs a new conversations.replies request.
+     *
+     * @param authentication the authentication credentials
+     * @param channel the channel ID
+     * @param ts the timestamp of the parent message
+     */
     public ConversationsRepliesRequest(final Authentication authentication, final String channel, final String ts) {
         super(authentication);
         this.channel = channel;
         this.ts = ts;
     }
 
+    /**
+     * Executes the conversations.replies API request.
+     *
+     * @return the response containing thread replies
+     */
     @Override
     public ConversationsRepliesResponse execute() {
         return parseResponse(request().execute().getContentAsString(), ConversationsRepliesResponse.class);
     }
 
+    /**
+     * Sets the pagination cursor for retrieving more results.
+     *
+     * @param cursor the pagination cursor
+     * @return this request instance for method chaining
+     */
     public ConversationsRepliesRequest cursor(final String cursor) {
         this.cursor = cursor;
         return this;
     }
 
+    /**
+     * Sets whether to include messages with timestamps matching boundaries.
+     *
+     * @param inclusive whether to include boundary timestamps
+     * @return this request instance for method chaining
+     */
     public ConversationsRepliesRequest inclusive(final Boolean inclusive) {
         this.inclusive = inclusive;
         return this;
     }
 
+    /**
+     * Sets the latest timestamp to include in results.
+     *
+     * @param latest the latest timestamp
+     * @return this request instance for method chaining
+     */
     public ConversationsRepliesRequest latest(final String latest) {
         this.latest = latest;
         return this;
     }
 
+    /**
+     * Sets the maximum number of messages to return.
+     *
+     * @param limit the maximum number of messages
+     * @return this request instance for method chaining
+     */
     public ConversationsRepliesRequest limit(final Integer limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Sets the oldest timestamp to include in results.
+     *
+     * @param oldest the oldest timestamp
+     * @return this request instance for method chaining
+     */
     public ConversationsRepliesRequest oldest(final String oldest) {
         this.oldest = oldest;
         return this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsRepliesResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/conversations/ConversationsRepliesResponse.java
@@ -25,22 +25,53 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response class for the conversations.replies API method.
+ * Contains thread messages and pagination metadata.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ConversationsRepliesResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public ConversationsRepliesResponse() {
+        super();
+    }
+
+    /** List of messages in the thread */
     protected List<Message> messages;
+
+    /** Metadata for pagination and response handling */
     protected ResponseMetadata responseMetadata;
+
+    /** Indicates if there are more messages available */
     protected Boolean hasMore;
 
+    /**
+     * Gets the list of messages in the thread.
+     *
+     * @return the list of messages
+     */
     public List<Message> getMessages() {
         return messages;
     }
 
+    /**
+     * Gets the response metadata for pagination.
+     *
+     * @return the response metadata
+     */
     public ResponseMetadata getResponseMetadata() {
         return responseMetadata;
     }
 
+    /**
+     * Checks if there are more messages available for pagination.
+     *
+     * @return true if more messages are available, false otherwise
+     */
     public boolean hasMore() {
         return hasMore == null ? false : hasMore;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesInfoRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesInfoRequest.java
@@ -19,39 +19,87 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request class for the files.info API method.
+ * Retrieves information about a specific file.
+ */
 public class FilesInfoRequest extends Request<FilesInfoResponse> {
 
+    /** The file ID to retrieve information for */
     protected final String file;
+
+    /** Number of items to return for paginated results */
     protected Integer count;
+
+    /** Maximum number of items to return */
     protected Integer limit;
+
+    /** Page number for pagination */
     protected Integer page;
+
+    /** Pagination cursor for retrieving more results */
     protected String cursor;
 
+    /**
+     * Constructs a new files.info request.
+     *
+     * @param authentication the authentication credentials
+     * @param file the file ID to retrieve information for
+     */
     public FilesInfoRequest(final Authentication authentication, final String file) {
         super(authentication);
         this.file = file;
     }
 
+    /**
+     * Executes the files.info API request.
+     *
+     * @return the response containing file information
+     */
     @Override
     public FilesInfoResponse execute() {
         return parseResponse(request().execute().getContentAsString(), FilesInfoResponse.class);
     }
 
+    /**
+     * Sets the number of items to return for paginated results.
+     *
+     * @param count the number of items to return
+     * @return this request instance for method chaining
+     */
     public FilesInfoRequest count(final Integer count) {
         this.count = count;
         return this;
     }
 
+    /**
+     * Sets the pagination cursor for retrieving more results.
+     *
+     * @param cursor the pagination cursor
+     * @return this request instance for method chaining
+     */
     public FilesInfoRequest cursor(final String cursor) {
         this.cursor = cursor;
         return this;
     }
 
+    /**
+     * Sets the maximum number of items to return.
+     *
+     * @param limit the maximum number of items
+     * @return this request instance for method chaining
+     */
     public FilesInfoRequest limit(final Integer limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Sets the page number for pagination.
+     *
+     * @param page the page number
+     * @return this request instance for method chaining
+     */
     public FilesInfoRequest page(final Integer page) {
         this.page = page;
         return this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesInfoResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesInfoResponse.java
@@ -24,22 +24,50 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response class for the files.info API method.
+ * Contains file information and pagination metadata.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FilesInfoResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public FilesInfoResponse() {
+        super();
+    }
+
+    /** The file information */
     protected File file;
 
+    /**
+     * Gets the file information.
+     *
+     * @return the file object
+     */
     public File getFile() {
         return file;
     }
 
+    /** Metadata for pagination and response handling */
     protected Map<String, Object> responseMetadata;
 
+    /**
+     * Gets the response metadata for pagination.
+     *
+     * @return the response metadata map
+     */
     public Map<String, Object> getResponseMetadata() {
         return responseMetadata;
     }
 
+    /**
+     * Gets the next pagination cursor from response metadata.
+     *
+     * @return the next cursor string, or null if not available
+     */
     public String getNextCursor() {
         return (String) responseMetadata.get("next_cursor");
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesListRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesListRequest.java
@@ -19,55 +19,124 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request class for the files.list API method.
+ * Retrieves a list of files matching specified criteria.
+ */
 public class FilesListRequest extends Request<FilesListResponse> {
 
+    /** Channel ID to filter files by */
     protected String channel;
+
+    /** File types to include (comma-separated) */
     protected String types;
+
+    /** User ID to filter files by */
     protected String user;
+
+    /** Number of items to return per page */
     protected Integer count;
+
+    /** Page number for pagination */
     protected Integer page;
+
+    /** Filter files created after this timestamp */
     protected Long tsFrom;
+
+    /** Filter files created before this timestamp */
     protected Long tsTo;
 
+    /**
+     * Constructs a new files.list request.
+     *
+     * @param authentication the authentication credentials
+     */
     public FilesListRequest(final Authentication authentication) {
         super(authentication);
     }
 
+    /**
+     * Executes the files.list API request.
+     *
+     * @return the response containing the list of files
+     */
     @Override
     public FilesListResponse execute() {
         return parseResponse(request().execute().getContentAsString(), FilesListResponse.class);
     }
 
+    /**
+     * Sets the channel ID to filter files by.
+     *
+     * @param channel the channel ID
+     * @return this request instance for method chaining
+     */
     public FilesListRequest channel(final String channel) {
         this.channel = channel;
         return this;
     }
 
+    /**
+     * Sets the number of items to return per page.
+     *
+     * @param count the number of items per page
+     * @return this request instance for method chaining
+     */
     public FilesListRequest count(final Integer count) {
         this.count = count;
         return this;
     }
 
+    /**
+     * Sets the page number for pagination.
+     *
+     * @param page the page number
+     * @return this request instance for method chaining
+     */
     public FilesListRequest page(final Integer page) {
         this.page = page;
         return this;
     }
 
+    /**
+     * Sets the timestamp to filter files created after.
+     *
+     * @param tsFrom the timestamp (Unix time)
+     * @return this request instance for method chaining
+     */
     public FilesListRequest tsFrom(final Long tsFrom) {
         this.tsFrom = tsFrom;
         return this;
     }
 
+    /**
+     * Sets the timestamp to filter files created before.
+     *
+     * @param tsTo the timestamp (Unix time)
+     * @return this request instance for method chaining
+     */
     public FilesListRequest tsTo(final Long tsTo) {
         this.tsTo = tsTo;
         return this;
     }
 
+    /**
+     * Sets the file types to include (comma-separated).
+     *
+     * @param types the file types
+     * @return this request instance for method chaining
+     */
     public FilesListRequest types(final String types) {
         this.types = types;
         return this;
     }
 
+    /**
+     * Sets the user ID to filter files by.
+     *
+     * @param user the user ID
+     * @return this request instance for method chaining
+     */
     public FilesListRequest user(final String user) {
         this.user = user;
         return this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesListResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/files/FilesListResponse.java
@@ -24,41 +24,101 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response class for the files.list API method.
+ * Contains a list of files and pagination information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FilesListResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public FilesListResponse() {
+        super();
+    }
+
+    /** List of files returned by the API */
     protected List<File> files;
 
+    /** Pagination information for the response */
     protected Paging paging;
 
+    /**
+     * Gets the list of files.
+     *
+     * @return the list of files
+     */
     public List<File> getFiles() {
         return files;
     }
 
+    /**
+     * Gets the pagination information.
+     *
+     * @return the paging object
+     */
     public Paging getPaging() {
         return paging;
     }
 
+    /**
+     * Pagination information for files.list response.
+     */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Paging {
+
+        /**
+         * Default constructor.
+         */
+        public Paging() {
+        }
+
+        /** Number of files in current page */
         protected Integer count;
+
+        /** Total number of files available */
         protected Integer total;
+
+        /** Current page number */
         protected Integer page;
+
+        /** Total number of pages available */
         protected Integer pages;
 
+        /**
+         * Gets the number of files in current page.
+         *
+         * @return the count of files in current page
+         */
         public Integer getCount() {
             return count;
         }
 
+        /**
+         * Gets the total number of files available.
+         *
+         * @return the total number of files
+         */
         public Integer getTotal() {
             return total;
         }
 
+        /**
+         * Gets the current page number.
+         *
+         * @return the current page number
+         */
         public Integer getPage() {
             return page;
         }
 
+        /**
+         * Gets the total number of pages available.
+         *
+         * @return the total number of pages
+         */
         public Integer getPages() {
             return pages;
         }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/team/TeamInfoRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/team/TeamInfoRequest.java
@@ -19,8 +19,16 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request to retrieve information about the Slack team/workspace.
+ */
 public class TeamInfoRequest extends Request<TeamInfoResponse> {
 
+    /**
+     * Creates a new team.info request with the specified authentication.
+     *
+     * @param authentication the authentication credentials
+     */
     public TeamInfoRequest(final Authentication authentication) {
         super(authentication);
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/team/TeamInfoResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/team/TeamInfoResponse.java
@@ -22,12 +22,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response from the team.info API method containing team information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TeamInfoResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public TeamInfoResponse() {
+        super();
+    }
+
+    /** The team information returned by the API. */
     protected Team team;
 
+    /**
+     * Returns the team information.
+     *
+     * @return the team details
+     */
     public Team getTeam() {
         return team;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersInfoRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersInfoRequest.java
@@ -19,11 +19,22 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request to retrieve information about a specific user in Slack.
+ */
 public class UsersInfoRequest extends Request<UsersInfoResponse> {
 
+    /** The user ID to retrieve information for. */
     protected final String user;
+    /** Whether to include locale information in the response. */
     protected Boolean includeLocale;
 
+    /**
+     * Creates a new users.info request with the specified authentication and user.
+     *
+     * @param authentication the authentication credentials
+     * @param user the user ID to get information for
+     */
     public UsersInfoRequest(final Authentication authentication, final String user) {
         super(authentication);
         this.user = user;
@@ -34,6 +45,12 @@ public class UsersInfoRequest extends Request<UsersInfoResponse> {
         return parseResponse(request().execute().getContentAsString(), UsersInfoResponse.class);
     }
 
+    /**
+     * Sets whether to include locale information in the response.
+     *
+     * @param includeLocale whether to include locale information
+     * @return this request instance for method chaining
+     */
     public UsersInfoRequest includeLocale(final Boolean includeLocale) {
         this.includeLocale = includeLocale;
         return this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersInfoResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersInfoResponse.java
@@ -22,12 +22,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response from the users.info API method containing user information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UsersInfoResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public UsersInfoResponse() {
+        super();
+    }
+
+    /** The user information returned by the API. */
     protected User user;
 
+    /**
+     * Returns the user information.
+     *
+     * @return the user details
+     */
     public User getUser() {
         return user;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersListRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersListRequest.java
@@ -19,13 +19,26 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.slack.api.Authentication;
 import org.codelibs.fess.ds.slack.api.Request;
 
+/**
+ * Request to retrieve a list of users in the Slack workspace.
+ * Supports pagination and various filtering options.
+ */
 public class UsersListRequest extends Request<UsersListResponse> {
 
+    /** Pagination cursor for retrieving the next page of results. */
     protected String cursor;
+    /** Whether to include locale information in the response. */
     protected Boolean includeLocale;
+    /** Whether to include presence information for users. */
     protected Boolean presence;
+    /** Maximum number of users to return per page. */
     protected Integer limit;
 
+    /**
+     * Creates a new users.list request with the specified authentication.
+     *
+     * @param authentication the authentication credentials
+     */
     public UsersListRequest(final Authentication authentication) {
         super(authentication);
     }
@@ -35,21 +48,45 @@ public class UsersListRequest extends Request<UsersListResponse> {
         return parseResponse(request().execute().getContentAsString(), UsersListResponse.class);
     }
 
+    /**
+     * Sets the pagination cursor for retrieving the next page of results.
+     *
+     * @param cursor the pagination cursor
+     * @return this request instance for method chaining
+     */
     public UsersListRequest cursor(final String cursor) {
         this.cursor = cursor;
         return this;
     }
 
+    /**
+     * Sets whether to include locale information in the response.
+     *
+     * @param includeLocale whether to include locale information
+     * @return this request instance for method chaining
+     */
     public UsersListRequest includeLocale(final Boolean includeLocale) {
         this.includeLocale = includeLocale;
         return this;
     }
 
+    /**
+     * Sets the maximum number of users to return per page.
+     *
+     * @param limit the maximum number of users per page
+     * @return this request instance for method chaining
+     */
     public UsersListRequest limit(final Integer limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Sets whether to include presence information for users.
+     *
+     * @param presence whether to include presence information
+     * @return this request instance for method chaining
+     */
     public UsersListRequest presence(final Boolean presence) {
         this.presence = presence;
         return this;

--- a/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersListResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/method/users/UsersListResponse.java
@@ -25,17 +25,39 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Response from the users.list API method containing a list of users and pagination metadata.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UsersListResponse extends Response {
 
+    /**
+     * Default constructor.
+     */
+    public UsersListResponse() {
+        super();
+    }
+
+    /** List of users returned by the API. */
     protected List<User> members;
+    /** Metadata for pagination including next cursor. */
     protected ResponseMetadata responseMetadata;
 
+    /**
+     * Returns the list of users.
+     *
+     * @return the list of users
+     */
     public List<User> getMembers() {
         return members;
     }
 
+    /**
+     * Returns the pagination metadata.
+     *
+     * @return the response metadata for pagination
+     */
     public ResponseMetadata getResponseMetadata() {
         return responseMetadata;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Attachment.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Attachment.java
@@ -19,22 +19,49 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack message attachment containing additional formatted content.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Attachment {
 
+    /**
+     * Default constructor.
+     */
+    public Attachment() {
+    }
+
+    /** Fallback text displayed when rich formatting is not supported. */
     protected String fallback;
+    /** Title of the attachment. */
     protected String title;
+    /** Main text content of the attachment. */
     protected String text;
 
+    /**
+     * Returns the fallback text for this attachment.
+     *
+     * @return the fallback text
+     */
     public String getFallback() {
         return fallback;
     }
 
+    /**
+     * Returns the title of this attachment.
+     *
+     * @return the attachment title
+     */
     public String getTitle() {
         return title;
     }
 
+    /**
+     * Returns the main text content of this attachment.
+     *
+     * @return the attachment text
+     */
     public String getText() {
         return text;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Bot.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Bot.java
@@ -19,22 +19,49 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack bot with basic identification and status information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Bot {
 
+    /**
+     * Default constructor.
+     */
+    public Bot() {
+    }
+
+    /** Unique identifier for the bot. */
     protected String id;
+    /** Display name of the bot. */
     protected String name;
+    /** Whether the bot has been deleted. */
     protected Boolean deleted;
 
+    /**
+     * Returns the unique identifier of this bot.
+     *
+     * @return the bot ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the display name of this bot.
+     *
+     * @return the bot name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns whether this bot has been deleted.
+     *
+     * @return true if the bot is deleted, false otherwise
+     */
     public boolean isDeleted() {
         return deleted == null ? false : deleted;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Channel.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Channel.java
@@ -21,38 +21,83 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack channel with metadata and member information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Channel {
 
+    /**
+     * Default constructor.
+     */
+    public Channel() {
+    }
+
+    /** Unique identifier for the channel. */
     protected String id;
+    /** Display name of the channel. */
     protected String name;
+    /** Whether this is a channel (as opposed to a direct message). */
     protected Boolean isChannel;
+    /** Whether the channel has been archived. */
     protected Boolean isArchived;
+    /** Whether the channel is private. */
     protected Boolean isPrivate;
 
+    /** List of member user IDs in the channel. */
     protected List<String> members;
 
+    /**
+     * Returns the unique identifier of this channel.
+     *
+     * @return the channel ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the display name of this channel.
+     *
+     * @return the channel name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns whether this is a channel (as opposed to a direct message).
+     *
+     * @return true if this is a channel, false otherwise
+     */
     public boolean isChannel() {
         return isChannel == null ? false : isChannel;
     }
 
+    /**
+     * Returns whether this channel has been archived.
+     *
+     * @return true if the channel is archived, false otherwise
+     */
     public boolean isArchived() {
         return isArchived == null ? false : isArchived;
     }
 
+    /**
+     * Returns whether this channel is private.
+     *
+     * @return true if the channel is private, false otherwise
+     */
     public boolean isPrivate() {
         return isPrivate == null ? false : isPrivate;
     }
 
+    /**
+     * Returns the list of member user IDs in this channel.
+     *
+     * @return the list of member IDs
+     */
     public List<String> getMembers() {
         return members;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Comment.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Comment.java
@@ -19,32 +19,71 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a comment on a file or other content in Slack.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Comment {
 
+    /**
+     * Default constructor.
+     */
+    public Comment() {
+    }
+
+    /** Unique identifier for the comment. */
     protected String id;
+    /** Timestamp when the comment was created. */
     protected Long created;
+    /** Timestamp of the comment. */
     protected Long timestamp;
+    /** User ID of the comment author. */
     protected String user;
+    /** The comment text content. */
     protected String comment;
 
+    /**
+     * Returns the unique identifier of this comment.
+     *
+     * @return the comment ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the timestamp when this comment was created.
+     *
+     * @return the creation timestamp
+     */
     public Long getCreated() {
         return created;
     }
 
+    /**
+     * Returns the timestamp of this comment.
+     *
+     * @return the comment timestamp
+     */
     public Long getTimestamp() {
         return timestamp;
     }
 
+    /**
+     * Returns the user ID of the comment author.
+     *
+     * @return the user ID
+     */
     public String getUser() {
         return user;
     }
 
+    /**
+     * Returns the text content of this comment.
+     *
+     * @return the comment text
+     */
     public String getComment() {
         return comment;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/File.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/File.java
@@ -20,91 +20,199 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack file object containing file metadata and access URLs.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class File {
 
+    /**
+     * Default constructor.
+     */
+    public File() {
+    }
+
+    /** Unique identifier for the file */
     protected String id;
+
+    /** Unix timestamp when the file was uploaded */
     protected Long timestamp;
+
+    /** Original filename */
     protected String name;
+
+    /** Title of the file */
     protected String title;
+
+    /** MIME type of the file */
     protected String mimetype;
+
+    /** User ID of the file uploader */
     protected String user;
+
+    /** File size in bytes */
     protected Long size;
+
+    /** Private URL for accessing the file */
     protected String urlPrivate;
+
+    /** Private download URL for the file */
     protected String urlPrivateDownload;
+
+    /** Permalink URL to the file */
     protected String permalink;
 
+    /** 64x64 pixel thumbnail URL */
     @JsonProperty("thumb_64")
     protected String thumb64;
 
+    /** 80x80 pixel thumbnail URL */
     @JsonProperty("thumb_80")
     protected String thumb80;
 
+    /** 360 pixel thumbnail URL */
     @JsonProperty("thumb_360")
     protected String thumb360;
 
+    /** Text preview content for the file */
     protected String preview;
 
+    /** Highlighted preview content with syntax highlighting */
     @JsonProperty("preview_highlight")
     protected String previewHighlight;
 
+    /**
+     * Gets the unique identifier for the file.
+     *
+     * @return the file ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Gets the Unix timestamp when the file was uploaded.
+     *
+     * @return the upload timestamp
+     */
     public Long getTimestamp() {
         return timestamp;
     }
 
+    /**
+     * Gets the original filename.
+     *
+     * @return the filename
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the title of the file.
+     *
+     * @return the file title
+     */
     public String getTitle() {
         return title;
     }
 
+    /**
+     * Gets the MIME type of the file.
+     *
+     * @return the MIME type
+     */
     public String getMimetype() {
         return mimetype;
     }
 
+    /**
+     * Gets the user ID of the file uploader.
+     *
+     * @return the user ID
+     */
     public String getUser() {
         return user;
     }
 
+    /**
+     * Gets the file size in bytes.
+     *
+     * @return the file size
+     */
     public Long getSize() {
         return size;
     }
 
+    /**
+     * Gets the private URL for accessing the file.
+     *
+     * @return the private URL
+     */
     public String getUrlPrivate() {
         return urlPrivate;
     }
 
+    /**
+     * Gets the private download URL for the file.
+     *
+     * @return the private download URL
+     */
     public String getUrlPrivateDownload() {
         return urlPrivateDownload;
     }
 
+    /**
+     * Gets the permalink URL to the file.
+     *
+     * @return the permalink URL
+     */
     public String getPermalink() {
         return permalink;
     }
 
+    /**
+     * Gets the 64x64 pixel thumbnail URL.
+     *
+     * @return the 64x64 thumbnail URL
+     */
     public String getThumb64() {
         return thumb64;
     }
 
+    /**
+     * Gets the 80x80 pixel thumbnail URL.
+     *
+     * @return the 80x80 thumbnail URL
+     */
     public String getThumb80() {
         return thumb80;
     }
 
+    /**
+     * Gets the 360 pixel thumbnail URL.
+     *
+     * @return the 360 pixel thumbnail URL
+     */
     public String getThumb360() {
         return thumb360;
     }
 
+    /**
+     * Gets the text preview content for the file.
+     *
+     * @return the preview content
+     */
     public String getPreview() {
         return preview;
     }
 
+    /**
+     * Gets the highlighted preview content with syntax highlighting.
+     *
+     * @return the highlighted preview content
+     */
     public String getPreviewHighlight() {
         return previewHighlight;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Message.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Message.java
@@ -21,67 +21,148 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack message with all associated metadata, files, and attachments.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Message {
 
+    /**
+     * Default constructor.
+     */
+    public Message() {
+    }
+
+    /** The type of message (e.g., "message"). */
     protected String type;
+    /** Timestamp of the message. */
     protected String ts;
+    /** User ID of the message author. */
     protected String user;
+    /** Text content of the message. */
     protected String text;
+    /** Subtype of the message (e.g., "bot_message", "file_share"). */
     protected String subtype;
+    /** Permanent link to the message. */
     protected String permalink;
+    /** Bot ID if the message was sent by a bot. */
     protected String botId;
+    /** Thread timestamp if this message is part of a thread. */
     protected String threadTs;
+    /** List of files attached to the message. */
     protected List<File> files;
+    /** Whether this message was broadcast from a thread to the channel. */
     protected Boolean isThreadBroadcast;
+    /** Comment associated with a file share. */
     protected Comment comment;
+    /** List of message attachments with rich formatting. */
     protected List<Attachment> attachments;
 
+    /**
+     * Returns the type of this message.
+     *
+     * @return the message type
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Returns the timestamp of this message.
+     *
+     * @return the message timestamp
+     */
     public String getTs() {
         return ts;
     }
 
+    /**
+     * Returns the user ID of the message author.
+     *
+     * @return the user ID
+     */
     public String getUser() {
         return user;
     }
 
+    /**
+     * Returns the text content of this message.
+     *
+     * @return the message text
+     */
     public String getText() {
         return text;
     }
 
+    /**
+     * Returns the subtype of this message.
+     *
+     * @return the message subtype
+     */
     public String getSubtype() {
         return subtype;
     }
 
+    /**
+     * Returns the permanent link to this message.
+     *
+     * @return the message permalink
+     */
     public String getPermalink() {
         return permalink;
     }
 
+    /**
+     * Returns the bot ID if this message was sent by a bot.
+     *
+     * @return the bot ID, or null if not sent by a bot
+     */
     public String getBotId() {
         return botId;
     }
 
+    /**
+     * Returns the thread timestamp if this message is part of a thread.
+     *
+     * @return the thread timestamp, or null if not part of a thread
+     */
     public String getThreadTs() {
         return threadTs;
     }
 
+    /**
+     * Returns the list of files attached to this message.
+     *
+     * @return the list of attached files
+     */
     public List<File> getFiles() {
         return files;
     }
 
+    /**
+     * Returns whether this message was broadcast from a thread to the channel.
+     *
+     * @return true if broadcast from thread, false otherwise
+     */
     public boolean isThreadBroadcast() {
         return isThreadBroadcast != null ? isThreadBroadcast : false;
     }
 
+    /**
+     * Returns the comment associated with a file share.
+     *
+     * @return the comment, or null if no comment
+     */
     public Comment getComment() {
         return comment;
     }
 
+    /**
+     * Returns the list of message attachments with rich formatting.
+     *
+     * @return the list of attachments
+     */
     public List<Attachment> getAttachments() {
         return attachments;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Profile.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Profile.java
@@ -20,64 +20,127 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a user profile in Slack with personal information and avatar images.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Profile {
 
+    /**
+     * Default constructor.
+     */
+    public Profile() {
+    }
+
+    /** The user's real name. */
     protected String realName;
+    /** The user's display name. */
     protected String displayName;
+    /** The user's email address. */
     protected String email;
 
+    /** URL of the user's 24x24 pixel avatar image. */
     @JsonProperty("image_24")
     protected String image24;
 
+    /** URL of the user's 32x32 pixel avatar image. */
     @JsonProperty("image_32")
     protected String image32;
 
+    /** URL of the user's 48x48 pixel avatar image. */
     @JsonProperty("image_48")
     protected String image48;
 
+    /** URL of the user's 72x72 pixel avatar image. */
     @JsonProperty("image_72")
     protected String image72;
 
+    /** URL of the user's 192x192 pixel avatar image. */
     @JsonProperty("image_192")
     protected String image192;
 
+    /** URL of the user's 512x512 pixel avatar image. */
     @JsonProperty("image_512")
     protected String image512;
 
+    /**
+     * Returns the user's real name.
+     *
+     * @return the real name
+     */
     public String getRealName() {
         return realName;
     }
 
+    /**
+     * Returns the user's display name.
+     *
+     * @return the display name
+     */
     public String getDisplayName() {
         return displayName;
     }
 
+    /**
+     * Returns the user's email address.
+     *
+     * @return the email address
+     */
     public String getEmail() {
         return email;
     }
 
+    /**
+     * Returns the URL of the user's 24x24 pixel avatar image.
+     *
+     * @return the 24x24 image URL
+     */
     public String getImage24() {
         return image24;
     }
 
+    /**
+     * Returns the URL of the user's 32x32 pixel avatar image.
+     *
+     * @return the 32x32 image URL
+     */
     public String getImage32() {
         return image32;
     }
 
+    /**
+     * Returns the URL of the user's 48x48 pixel avatar image.
+     *
+     * @return the 48x48 image URL
+     */
     public String getImage48() {
         return image48;
     }
 
+    /**
+     * Returns the URL of the user's 72x72 pixel avatar image.
+     *
+     * @return the 72x72 image URL
+     */
     public String getImage72() {
         return image72;
     }
 
+    /**
+     * Returns the URL of the user's 192x192 pixel avatar image.
+     *
+     * @return the 192x192 image URL
+     */
     public String getImage192() {
         return image192;
     }
 
+    /**
+     * Returns the URL of the user's 512x512 pixel avatar image.
+     *
+     * @return the 512x512 image URL
+     */
     public String getImage512() {
         return image512;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/ResponseMetadata.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/ResponseMetadata.java
@@ -19,12 +19,27 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Contains metadata for paginated Slack API responses.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ResponseMetadata {
 
+    /**
+     * Default constructor.
+     */
+    public ResponseMetadata() {
+    }
+
+    /** Cursor for retrieving the next page of results. */
     protected String nextCursor;
 
+    /**
+     * Returns the cursor for retrieving the next page of results.
+     *
+     * @return the next cursor, or null if no more pages
+     */
     public String getNextCursor() {
         return nextCursor;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/Team.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/Team.java
@@ -19,22 +19,50 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack team (workspace) with basic identification information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Team {
 
+    /**
+     * Default constructor for Team.
+     */
+    public Team() {
+        // Default constructor
+    }
+
+    /** Unique identifier for the team. */
     protected String id;
+    /** Display name of the team. */
     protected String name;
+    /** Domain name of the team. */
     protected String domain;
 
+    /**
+     * Returns the unique identifier of this team.
+     *
+     * @return the team ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the display name of this team.
+     *
+     * @return the team name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the domain name of this team.
+     *
+     * @return the team domain
+     */
     public String getDomain() {
         return domain;
     }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/type/User.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/type/User.java
@@ -19,33 +19,73 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+/**
+ * Represents a Slack user with identification and profile information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class User {
 
+    /**
+     * Default constructor for User.
+     */
+    public User() {
+        // Default constructor
+    }
+
+    /** Unique identifier for the user. */
     protected String id;
+    /** Username of the user. */
     protected String name;
+    /** Whether the user has been deleted. */
     protected Boolean deleted;
+    /** Real name of the user. */
     protected String realName;
 
+    /** Detailed profile information for the user. */
     protected Profile profile;
 
+    /**
+     * Returns the unique identifier of this user.
+     *
+     * @return the user ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the username of this user.
+     *
+     * @return the username
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns whether this user has been deleted.
+     *
+     * @return true if the user is deleted, false otherwise
+     */
     public boolean isDeleted() {
         return deleted == null ? false : deleted;
     }
 
+    /**
+     * Returns the real name of this user.
+     *
+     * @return the real name
+     */
     public String getRealName() {
         return realName;
     }
 
+    /**
+     * Returns the detailed profile information for this user.
+     *
+     * @return the user profile
+     */
     public Profile getProfile() {
         return profile;
     }


### PR DESCRIPTION
This pull request adds comprehensive JavaDoc comments to multiple classes in the Slack DataStore integration, including client classes, request/response models, and API type definitions. These comments enhance code readability and maintainability by providing clear documentation for each class and method. No logic or functionality has been changed.
