### PR TITLE
Update version to 15.9.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-slack</artifactId>
 	<packaging>jar</packaging>
 	<name>Slack Data Store</name>
-	<version>15.8.1-SNAPSHOT</version>
+	<version>15.9.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-slack.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-slack.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.8.0</version>
+		<version>15.9.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

Bump version for the 15.9.0 development cycle.

Depends on upstream Fess artifacts (`fess-parent`, and where applicable `fess-suggest`, `fess-crawler`, `fess-crawler-playwright`, `fess`) at `15.9.0-SNAPSHOT`, which must already be deployed to the Maven snapshot repository before CI runs here.

## Test plan

- [ ] CI build passes against `15.9.0-SNAPSHOT` upstreams