### PR TITLE
test: enable the test suite and add a Slack Web API mock server

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/slack/api/Request.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/Request.java
@@ -43,10 +43,40 @@ public abstract class Request<T extends Response> {
     /** Function for creating DELETE HTTP requests */
     public static final Function<String, CurlRequest> DELETE = Curl::delete;
 
-    /** Base URL for all Slack API endpoints */
-    protected static final String SLACK_API_ENDPOINT = "https://slack.com/api/";
+    /** The default Slack Web API endpoint. */
+    protected static final String DEFAULT_SLACK_API_ENDPOINT = "https://slack.com/api/";
+
+    /** The Slack Web API endpoint in effect. Overridable for testing. */
+    private static volatile String slackApiEndpoint = DEFAULT_SLACK_API_ENDPOINT;
+
     /** Jackson ObjectMapper for JSON parsing */
     protected static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Returns the Slack Web API endpoint currently in effect.
+     *
+     * @return the endpoint URL, always ending with a slash
+     */
+    protected static String getEndpoint() {
+        return slackApiEndpoint;
+    }
+
+    /**
+     * Overrides the Slack Web API endpoint. Intended for testing against a local
+     * stub server; production code must not call this.
+     *
+     * @param endpoint the endpoint URL, which must end with a slash
+     */
+    public static void setEndpoint(final String endpoint) {
+        slackApiEndpoint = endpoint;
+    }
+
+    /**
+     * Restores the Slack Web API endpoint to {@link #DEFAULT_SLACK_API_ENDPOINT}.
+     */
+    public static void resetEndpoint() {
+        slackApiEndpoint = DEFAULT_SLACK_API_ENDPOINT;
+    }
 
     /** Authentication credentials for Slack API access */
     protected Authentication authentication;
@@ -94,7 +124,7 @@ public abstract class Request<T extends Response> {
      */
     public CurlRequest getCurlRequest(final Function<String, CurlRequest> method, final String path) {
         final StringBuilder buf = new StringBuilder(100);
-        buf.append(SLACK_API_ENDPOINT);
+        buf.append(getEndpoint());
         if (path != null) {
             buf.append(path);
         }

--- a/src/main/java/org/codelibs/fess/ds/slack/api/Request.java
+++ b/src/main/java/org/codelibs/fess/ds/slack/api/Request.java
@@ -66,8 +66,14 @@ public abstract class Request<T extends Response> {
      * stub server; production code must not call this.
      *
      * @param endpoint the endpoint URL, which must end with a slash
+     * @throws IllegalArgumentException if {@code endpoint} is {@code null} or does not end with
+     *             a slash; either would otherwise silently concatenate into a malformed URL
+     *             such as {@code "nullteam.info"} or {@code ".../apiteam.info"}
      */
     public static void setEndpoint(final String endpoint) {
+        if (endpoint == null || !endpoint.endsWith("/")) {
+            throw new IllegalArgumentException("endpoint must be non-null and end with '/': " + endpoint);
+        }
         slackApiEndpoint = endpoint;
     }
 

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackApiMockServer.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackApiMockServer.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.ds.slack;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.codelibs.fess.ds.slack.api.Request;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * A local stand-in for the Slack Web API, backed by the JDK's built-in HTTP
+ * server. Responses are queued per path and consumed in order; a path with an
+ * empty queue answers {@link #DEFAULT_RESPONSE_BODY} so that incidental calls,
+ * such as the user and channel preload in the {@link SlackClient} constructor,
+ * do not have to be scripted by every test.
+ */
+public class SlackApiMockServer {
+
+    /**
+     * The body returned for a path with no queued response.
+     *
+     * <p>
+     * A bare {@code {"ok":true}} is not enough: {@link SlackClient}'s
+     * constructor unconditionally preloads users and channels, and its
+     * paging loops call {@code getMembers()}/{@code getChannels()} and
+     * {@code getResponseMetadata()} without a null check, so a body missing
+     * those fields throws a {@link NullPointerException} before a single test
+     * runs. This body carries every field any list/paging response class
+     * looks at &mdash; {@code members}, {@code channels}, {@code messages},
+     * {@code files}, {@code response_metadata.next_cursor} and {@code paging}
+     * &mdash; so it satisfies every endpoint. Every response class is
+     * annotated {@code @JsonIgnoreProperties(ignoreUnknown = true)}, so the
+     * extra fields a particular endpoint does not use are silently ignored.
+     * Do not "simplify" this back to {@code {"ok":true}}.
+     */
+    static final String DEFAULT_RESPONSE_BODY = "{\"ok\":true,\"members\":[],\"channels\":[],\"messages\":[],\"files\":[],"
+            + "\"response_metadata\":{\"next_cursor\":\"\"},\"paging\":{\"count\":0,\"total\":0,\"page\":1,\"pages\":1}}";
+
+    private HttpServer server;
+
+    private final Map<String, List<MockResponse>> queued = new ConcurrentHashMap<>();
+
+    private final Map<String, List<Map<String, String>>> received = new ConcurrentHashMap<>();
+
+    /** A canned HTTP response. */
+    public static class MockResponse {
+        final int statusCode;
+        final String body;
+        final Map<String, String> headers;
+
+        MockResponse(final int statusCode, final String body, final Map<String, String> headers) {
+            this.statusCode = statusCode;
+            this.body = body;
+            this.headers = headers;
+        }
+    }
+
+    /**
+     * Builds an HTTP 200 response carrying the given JSON body.
+     *
+     * @param body the JSON body
+     * @return the response
+     */
+    public static MockResponse json(final String body) {
+        return new MockResponse(200, body, Collections.emptyMap());
+    }
+
+    /**
+     * Builds an HTTP 429 response carrying a Retry-After header, matching what
+     * Slack returns when a method exceeds its rate limit.
+     *
+     * @param retryAfterSeconds the value of the Retry-After header, in seconds
+     * @return the response
+     */
+    public static MockResponse rateLimited(final int retryAfterSeconds) {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("Retry-After", Integer.toString(retryAfterSeconds));
+        return new MockResponse(429, "{\"ok\":false,\"error\":\"ratelimited\"}", headers);
+    }
+
+    /**
+     * Builds a response with an arbitrary status code and body.
+     *
+     * @param code the HTTP status code
+     * @param body the response body
+     * @return the response
+     */
+    public static MockResponse status(final int code, final String body) {
+        return new MockResponse(code, body, Collections.emptyMap());
+    }
+
+    /**
+     * Starts the server on an ephemeral port and points the Slack client at it.
+     *
+     * @throws IOException if the server cannot bind
+     */
+    public void start() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/", this::handle);
+        server.setExecutor(null);
+        server.start();
+        Request.setEndpoint(getEndpoint());
+    }
+
+    /**
+     * Stops the server and restores the production endpoint.
+     */
+    public void stop() {
+        Request.resetEndpoint();
+        if (server != null) {
+            server.stop(0);
+            server = null;
+        }
+    }
+
+    /**
+     * Returns the base URL this server is listening on.
+     *
+     * @return the endpoint URL, ending with a slash
+     */
+    public String getEndpoint() {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + "/api/";
+    }
+
+    /**
+     * Queues one response for the given path. Responses are consumed in order.
+     *
+     * @param path the request path, for example <code>/api/team.info</code>
+     * @param response the response to return
+     */
+    public void enqueue(final String path, final MockResponse response) {
+        queued.computeIfAbsent(path, k -> Collections.synchronizedList(new ArrayList<>())).add(response);
+    }
+
+    /**
+     * Returns how many times the given path was requested.
+     *
+     * @param path the request path
+     * @return the request count
+     */
+    public int getRequestCount(final String path) {
+        return getRequests(path).size();
+    }
+
+    /**
+     * Returns the query parameters of each request made to the given path, in
+     * arrival order.
+     *
+     * @param path the request path
+     * @return the recorded query parameter maps
+     */
+    public List<Map<String, String>> getRequests(final String path) {
+        return received.getOrDefault(path, Collections.emptyList());
+    }
+
+    private void handle(final HttpExchange exchange) throws IOException {
+        final String path = exchange.getRequestURI().getPath();
+        received.computeIfAbsent(path, k -> Collections.synchronizedList(new ArrayList<>()))
+                .add(parseQuery(exchange.getRequestURI().getRawQuery()));
+
+        final List<MockResponse> responses = queued.get(path);
+        MockResponse response = null;
+        if (responses != null) {
+            synchronized (responses) {
+                if (!responses.isEmpty()) {
+                    response = responses.remove(0);
+                }
+            }
+        }
+        if (response == null) {
+            response = json(DEFAULT_RESPONSE_BODY);
+        }
+
+        final byte[] payload = response.body.getBytes(StandardCharsets.UTF_8);
+        response.headers.forEach((k, v) -> exchange.getResponseHeaders().add(k, v));
+        exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(response.statusCode, payload.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(payload);
+        }
+    }
+
+    private Map<String, String> parseQuery(final String rawQuery) {
+        final Map<String, String> params = new LinkedHashMap<>();
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return params;
+        }
+        for (final String pair : rawQuery.split("&")) {
+            final int eq = pair.indexOf('=');
+            if (eq < 0) {
+                params.put(URLDecoder.decode(pair, StandardCharsets.UTF_8), "");
+            } else {
+                params.put(URLDecoder.decode(pair.substring(0, eq), StandardCharsets.UTF_8),
+                        URLDecoder.decode(pair.substring(eq + 1), StandardCharsets.UTF_8));
+            }
+        }
+        return params;
+    }
+}

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackApiMockServerTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackApiMockServerTest.java
@@ -50,12 +50,42 @@ public class SlackApiMockServerTest extends UnitDsTestCase {
         assertEquals(1, server.getRequestCount("/api/team.info"));
     }
 
+    /**
+     * The {@link SlackClient} constructor unconditionally preloads users via
+     * {@code usersList().limit(100).execute()} (see {@code newClient()} and
+     * {@code SlackClient.DEFAULT_USER_COUNT}), sending a plain
+     * {@code limit=100} query parameter. Verify the parameter both arrives
+     * and is parsed back with its key and value intact.
+     */
     @Test
     public void test_recordsQueryParameters() {
-        server.enqueue("/api/team.info", SlackApiMockServer.json("{\"ok\":true}"));
-        newClient().teamInfo().execute();
-        final List<Map<String, String>> requests = server.getRequests("/api/team.info");
+        newClient();
+        final List<Map<String, String>> requests = server.getRequests("/api/users.list");
         assertEquals(1, requests.size());
+        assertEquals("100", requests.get(0).get("limit"));
+    }
+
+    /**
+     * {@code cursor} is a free-form string parameter (see
+     * {@code UsersListRequest.cursor(String)}), so drive a value containing a
+     * space and an ampersand through the real client and confirm
+     * {@link SlackApiMockServer}'s query parser decodes exactly what
+     * {@code org.codelibs.curl.CurlRequest#param} encoded. Phase 1's first
+     * task depends on this decoding being correct: it asserts the parsed
+     * {@code types} parameter across successive {@code files.list} pages, and
+     * a broken decoder would fail that assertion for a reason no one could
+     * locate.
+     */
+    @Test
+    public void test_decodesUrlEncodedQueryParameterValue() {
+        final SlackClient client = newClient();
+        client.usersList().cursor("a value with a space & an ampersand").execute();
+
+        final List<Map<String, String>> requests = server.getRequests("/api/users.list");
+        // index 0 is the constructor's own users.list preload (asserted in
+        // test_recordsQueryParameters); index 1 is this test's explicit call.
+        assertEquals(2, requests.size());
+        assertEquals("a value with a space & an ampersand", requests.get(1).get("cursor"));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackApiMockServerTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackApiMockServerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.ds.slack;
+
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.ds.slack.api.method.team.TeamInfoResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class SlackApiMockServerTest extends UnitDsTestCase {
+
+    private SlackApiMockServer server;
+
+    @Override
+    public void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        server = new SlackApiMockServer();
+        server.start();
+    }
+
+    @Override
+    public void tearDown(final TestInfo testInfo) throws Exception {
+        server.stop();
+        super.tearDown(testInfo);
+    }
+
+    @Test
+    public void test_serveJson() {
+        server.enqueue("/api/team.info",
+                SlackApiMockServer.json("{\"ok\":true,\"team\":{\"id\":\"T1\",\"name\":\"NAME\",\"domain\":\"DOMAIN\"}}"));
+        final SlackClient client = newClient();
+        final TeamInfoResponse response = client.teamInfo().execute();
+        assertTrue(response.ok());
+        assertEquals("T1", response.getTeam().getId());
+        assertEquals(1, server.getRequestCount("/api/team.info"));
+    }
+
+    @Test
+    public void test_recordsQueryParameters() {
+        server.enqueue("/api/team.info", SlackApiMockServer.json("{\"ok\":true}"));
+        newClient().teamInfo().execute();
+        final List<Map<String, String>> requests = server.getRequests("/api/team.info");
+        assertEquals(1, requests.size());
+    }
+
+    /**
+     * The client cannot yet observe status codes, so verify the 429 shape with a
+     * direct HTTP call. The retry layer in Phase 2 depends on this working.
+     */
+    @Test
+    public void test_rateLimitedResponseCarriesRetryAfter() throws Exception {
+        server.enqueue("/api/team.info", SlackApiMockServer.rateLimited(7));
+
+        final java.net.HttpURLConnection conn =
+                (java.net.HttpURLConnection) java.net.URI.create(server.getEndpoint() + "team.info").toURL().openConnection();
+        try {
+            assertEquals(429, conn.getResponseCode());
+            assertEquals("7", conn.getHeaderField("Retry-After"));
+        } finally {
+            conn.disconnect();
+        }
+        assertEquals(1, server.getRequestCount("/api/team.info"));
+    }
+
+    private SlackClient newClient() {
+        final org.codelibs.fess.entity.DataStoreParams paramMap = new org.codelibs.fess.entity.DataStoreParams();
+        paramMap.put("token", "xoxb-test");
+        return new SlackClient(paramMap);
+    }
+}

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackClientTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackClientTest.java
@@ -15,12 +15,11 @@
  */
 package org.codelibs.fess.ds.slack;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.util.List;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.ds.slack.api.method.bots.BotsInfoRequest;
 import org.codelibs.fess.ds.slack.api.method.bots.BotsInfoResponse;
 import org.codelibs.fess.ds.slack.api.method.conversations.ConversationsHistoryRequest;
@@ -42,12 +41,9 @@ import org.codelibs.fess.ds.slack.api.type.File;
 import org.codelibs.fess.ds.slack.api.type.Message;
 import org.codelibs.fess.ds.slack.api.type.Team;
 import org.codelibs.fess.ds.slack.api.type.User;
-import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.ds.slack.UnitDsTestCase;
 
 public class SlackClientTest extends UnitDsTestCase {
-
-    private static Logger logger = LogManager.getLogger(SlackClientTest.class);
 
     @Override
     protected String prepareConfigFile() {
@@ -69,119 +65,7 @@ public class SlackClientTest extends UnitDsTestCase {
         super.tearDown(testInfo);
     }
 
-    public void testProduction() {
-        // doProductionTest();
-    }
-
-    protected void doProductionTest() {
-        final SlackClient client = new SlackClient(new DataStoreParams());
-        doConversationsListTest(client);
-        doConversationsHistoryTest(client);
-        doConversationsInfoTest(client);
-        doUsersListTest(client);
-        doUsersInfoTest(client);
-        doFilesListTest(client);
-        doFilesInfoTest(client);
-        // doBotsInfoTest(client, "");
-        // doChatGetPermalinkTest(client, "", "");
-        // doConversationsRepliesTest(client, "", "");
-        doTeamInfoTest(client);
-    }
-
-    protected void doConversationsListTest(final SlackClient client) {
-        logger.info("----------ConversationsList----------");
-        logger.info("Channels: ");
-        for (final Channel channel : client.conversationsList().limit(5).execute().getChannels()) {
-            logger.info("#" + channel.getName());
-        }
-    }
-
-    protected void doConversationsHistoryTest(final SlackClient client) {
-        logger.info("----------ConversationsHistory----------");
-        final Channel channel = client.conversationsList().limit(1).execute().getChannels().get(0);
-        logger.info("History of #" + channel.getName());
-        final ConversationsHistoryResponse response = client.conversationsHistory(channel.getId()).limit(5).execute();
-        for (final Message message : response.getMessages()) {
-            logger.info(message.getUser() + ": " + message.getText());
-        }
-        logger.info("hasMore: " + response.hasMore());
-    }
-
-    protected void doConversationsInfoTest(final SlackClient client) {
-        logger.info("----------ConversationsInfo----------");
-        final String id = client.conversationsList().limit(1).execute().getChannels().get(0).getId();
-        logger.info("Channel: " + id);
-        final Channel channel = client.conversationsInfo(id).execute().getChannel();
-        logger.info("#" + channel.getName());
-    }
-
-    protected void doConversationsRepliesTest(final SlackClient client, final String channel, final String ts) {
-        logger.info("----------ConversationsReplies----------");
-        final ConversationsRepliesResponse response = client.conversationsReplies(channel, ts).execute();
-        final List<Message> messages = response.getMessages();
-        for (int i = 1; i < messages.size(); i++) {
-            logger.info(messages.get(i).getUser() + ": " + messages.get(i).getText());
-        }
-        logger.info("hasMore: " + response.hasMore());
-    }
-
-    protected void doUsersListTest(final SlackClient client) {
-        logger.info("----------UsersList----------");
-        logger.info("Users: ");
-        final UsersListResponse response = client.usersList().limit(5).execute();
-        for (final User user : response.getMembers()) {
-            logger.info(user.getProfile().getDisplayName());
-        }
-        logger.info("next_cursor: " + response.getResponseMetadata().getNextCursor());
-    }
-
-    protected void doUsersInfoTest(final SlackClient client) {
-        logger.info("----------UsersInfo----------");
-        final String id = client.usersList().limit(1).execute().getMembers().get(0).getId();
-        logger.info("User: " + id);
-        final User user = client.usersInfo(id).execute().getUser();
-        logger.info(user.getProfile().getDisplayName());
-    }
-
-    protected void doFilesListTest(final SlackClient client) {
-        logger.info("----------FilesList----------");
-        logger.info("Files: ");
-        final FilesListResponse response = client.filesList().count(5).execute();
-        for (final File file : response.getFiles()) {
-            logger.info(file.getName() + "  " + file.getMimetype());
-        }
-        logger.info("count: " + response.getPaging().getCount());
-    }
-
-    protected void doFilesInfoTest(final SlackClient client) {
-        logger.info("----------FilesInfo----------");
-        final String id = client.filesList().count(1).execute().getFiles().get(0).getId();
-        logger.info("File: " + id);
-        final File file = client.filesInfo(id).execute().getFile();
-        logger.info(file.getName() + "  " + file.getMimetype());
-    }
-
-    protected void doBotsInfoTest(final SlackClient client, final String id) {
-        logger.info("----------BotsInfo----------");
-        logger.info("Bot: " + id);
-        final Bot bot = client.botsInfo().bot(id).execute().getBot();
-        logger.info(bot.getName());
-    }
-
-    protected void doChatGetPermalinkTest(final SlackClient client, final String channel, final String ts) {
-        logger.info("----------ChatGetPermalink----------");
-        logger.info("Channel: " + channel + ", Timestamp: " + ts);
-        final String link = client.chatGetPermalink(channel, ts).execute().getPermalink();
-        logger.info(link);
-    }
-
-    protected void doTeamInfoTest(final SlackClient client) {
-        logger.info("----------TeamInfo----------");
-        logger.info("Team: ");
-        final Team team = client.teamInfo().execute().getTeam();
-        logger.info(team.getName() + " https://" + team.getDomain() + ".slack.com/");
-    }
-
+    @Test
     public void testConversationsList() {
         final String content = "" + //
                 "{" + //
@@ -205,12 +89,13 @@ public class SlackClientTest extends UnitDsTestCase {
         assertTrue(response.ok());
         final List<Channel> channels = response.getChannels();
         for (int i = 0; i < channels.size(); i++) {
-            assertEquals(channels.get(i).getId(), "CHANNEL_ID" + i);
-            assertEquals(channels.get(i).getName(), "CHANNEL_Name" + i);
+            assertEquals("CHANNEL_ID" + i, channels.get(i).getId());
+            assertEquals("CHANNEL_Name" + i, channels.get(i).getName());
         }
-        assertEquals(response.getResponseMetadata().getNextCursor(), "NEXT_CURSOR");
+        assertEquals("NEXT_CURSOR", response.getResponseMetadata().getNextCursor());
     }
 
+    @Test
     public void testConversationsHistory() {
         final String content = "" + //
                 "{" + //
@@ -243,17 +128,18 @@ public class SlackClientTest extends UnitDsTestCase {
         final ConversationsHistoryResponse response = request.parseResponse(content, ConversationsHistoryResponse.class);
         assertTrue(response.ok());
         final List<Message> messages = response.getMessages();
-        assertEquals(messages.get(0).getUser(), "USER");
-        assertEquals(messages.get(0).getText(), "TEXT");
-        assertEquals(messages.get(0).getTs(), "1234567890.000100");
+        assertEquals("USER", messages.get(0).getUser());
+        assertEquals("TEXT", messages.get(0).getText());
+        assertEquals("1234567890.000100", messages.get(0).getTs());
         final Attachment attach = messages.get(1).getAttachments().get(0);
-        assertEquals(attach.getFallback(), "FALLBACK");
+        assertEquals("FALLBACK", attach.getFallback());
         final File file = messages.get(1).getFiles().get(0);
-        assertEquals(file.getId(), "FILE_ID");
+        assertEquals("FILE_ID", file.getId());
         assertTrue(response.hasMore());
-        assertEquals(response.getResponseMetadata().getNextCursor(), "NEXT_CURSOR");
+        assertEquals("NEXT_CURSOR", response.getResponseMetadata().getNextCursor());
     }
 
+    @Test
     public void testUsersList() {
         final String content = "" + //
                 "{" + //
@@ -279,12 +165,13 @@ public class SlackClientTest extends UnitDsTestCase {
         assertTrue(response.ok());
         final List<User> members = response.getMembers();
         for (int i = 0; i < members.size(); i++) {
-            assertEquals(members.get(i).getId(), "ID" + i);
-            assertEquals(members.get(i).getName(), "NAME" + i);
-            assertEquals(members.get(i).getProfile().getDisplayName(), "DISPLAY_NAME" + i);
+            assertEquals("ID" + i, members.get(i).getId());
+            assertEquals("NAME" + i, members.get(i).getName());
+            assertEquals("DISPLAY_NAME" + i, members.get(i).getProfile().getDisplayName());
         }
     }
 
+    @Test
     public void testFilesList() {
         final String content = "" + //
                 "{" + //
@@ -309,13 +196,14 @@ public class SlackClientTest extends UnitDsTestCase {
         assertTrue(response.ok());
         final List<File> files = response.getFiles();
         for (int i = 0; i < files.size(); i++) {
-            assertEquals(files.get(i).getId(), "FILE_ID" + i);
-            assertEquals(files.get(i).getTimestamp(), Long.valueOf(1234567890));
-            assertEquals(files.get(i).getThumb360(), "THUMBNAIL" + i);
+            assertEquals("FILE_ID" + i, files.get(i).getId());
+            assertEquals(Long.valueOf(1234567890), files.get(i).getTimestamp());
+            assertEquals("THUMBNAIL" + i, files.get(i).getThumb360());
         }
-        assertEquals(response.getPaging().getCount(), Integer.valueOf(2));
+        assertEquals(Integer.valueOf(2), response.getPaging().getCount());
     }
 
+    @Test
     public void testBotsInfo() {
         final String content = "" + //
                 "{" + //
@@ -328,10 +216,11 @@ public class SlackClientTest extends UnitDsTestCase {
         final BotsInfoResponse response = new BotsInfoRequest(null).parseResponse(content, BotsInfoResponse.class);
         assertTrue(response.ok());
         final Bot bot = response.getBot();
-        assertEquals(bot.getId(), "BOT_ID");
-        assertEquals(bot.getName(), "BOT_NAME");
+        assertEquals("BOT_ID", bot.getId());
+        assertEquals("BOT_NAME", bot.getName());
     }
 
+    @Test
     public void testTeamInfo() {
         final String content = "" + //
                 "{" + //
@@ -345,12 +234,13 @@ public class SlackClientTest extends UnitDsTestCase {
         final TeamInfoResponse response = new TeamInfoRequest(null).parseResponse(content, TeamInfoResponse.class);
         assertTrue(response.ok());
         final Team team = response.getTeam();
-        assertEquals(team.getId(), "TEAM_ID");
-        assertEquals(team.getName(), "TEAM_NAME");
-        assertEquals(team.getDomain(), "TEAM_DOMAIN");
+        assertEquals("TEAM_ID", team.getId());
+        assertEquals("TEAM_NAME", team.getName());
+        assertEquals("TEAM_DOMAIN", team.getDomain());
     }
 
     // Test error responses
+    @Test
     public void testConversationsList_errorResponse() {
         final String content = "" + //
                 "{" + //
@@ -362,6 +252,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertFalse(response.ok());
     }
 
+    @Test
     public void testConversationsHistory_errorResponse() {
         final String content = "" + //
                 "{" + //
@@ -373,6 +264,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertFalse(response.ok());
     }
 
+    @Test
     public void testUsersList_errorResponse() {
         final String content = "" + //
                 "{" + //
@@ -383,6 +275,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertFalse(response.ok());
     }
 
+    @Test
     public void testFilesList_errorResponse() {
         final String content = "" + //
                 "{" + //
@@ -393,6 +286,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertFalse(response.ok());
     }
 
+    @Test
     public void testBotsInfo_errorResponse() {
         final String content = "" + //
                 "{" + //
@@ -403,6 +297,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertFalse(response.ok());
     }
 
+    @Test
     public void testTeamInfo_errorResponse() {
         final String content = "" + //
                 "{" + //
@@ -414,6 +309,7 @@ public class SlackClientTest extends UnitDsTestCase {
     }
 
     // Test edge cases
+    @Test
     public void testConversationsList_emptyChannels() {
         final String content = "" + //
                 "{" + //
@@ -432,6 +328,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertEquals("", response.getResponseMetadata().getNextCursor());
     }
 
+    @Test
     public void testConversationsHistory_emptyMessages() {
         final String content = "" + //
                 "{" + //
@@ -451,6 +348,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertFalse(response.hasMore());
     }
 
+    @Test
     public void testUsersList_emptyMembers() {
         final String content = "" + //
                 "{" + //
@@ -464,6 +362,7 @@ public class SlackClientTest extends UnitDsTestCase {
         assertEquals(0, members.size());
     }
 
+    @Test
     public void testFilesList_emptyFiles() {
         final String content = "" + //
                 "{" + //
@@ -482,6 +381,7 @@ public class SlackClientTest extends UnitDsTestCase {
     }
 
     // Test multiple attachments in a single message
+    @Test
     public void testConversationsHistory_multipleAttachments() {
         final String content = "" + //
                 "{" + //
@@ -516,6 +416,7 @@ public class SlackClientTest extends UnitDsTestCase {
     }
 
     // Test multiple files in a single message
+    @Test
     public void testConversationsHistory_multipleFiles() {
         final String content = "" + //
                 "{" + //
@@ -550,6 +451,7 @@ public class SlackClientTest extends UnitDsTestCase {
     }
 
     // Test ConversationsRepliesResponse
+    @Test
     public void testConversationsReplies() {
         final String content = "" + //
                 "{" + //
@@ -586,6 +488,7 @@ public class SlackClientTest extends UnitDsTestCase {
     }
 
     // Test pagination
+    @Test
     public void testConversationsList_withPagination() {
         final String content = "" + //
                 "{" + //
@@ -611,6 +514,7 @@ public class SlackClientTest extends UnitDsTestCase {
     }
 
     // Test FilesListResponse with paging
+    @Test
     public void testFilesList_withPaging() {
         final String content = "" + //
                 "{" + //

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreExceptionTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreExceptionTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.ds.slack;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import org.codelibs.fess.ds.slack.UnitDsTestCase;
@@ -24,6 +25,7 @@ import org.codelibs.fess.ds.slack.UnitDsTestCase;
  */
 public class SlackDataStoreExceptionTest extends UnitDsTestCase {
 
+    @Test
     public void test_constructor_withMessage() {
         final String message = "Test error message";
         final SlackDataStoreException exception = new SlackDataStoreException(message);
@@ -33,6 +35,7 @@ public class SlackDataStoreExceptionTest extends UnitDsTestCase {
         assertNull(exception.getCause());
     }
 
+    @Test
     public void test_constructor_withMessageAndCause() {
         final String message = "Test error message";
         final Throwable cause = new RuntimeException("Cause exception");
@@ -45,6 +48,7 @@ public class SlackDataStoreExceptionTest extends UnitDsTestCase {
         assertEquals("Cause exception", exception.getCause().getMessage());
     }
 
+    @Test
     public void test_constructor_withCause() {
         final Throwable cause = new IllegalArgumentException("Invalid argument");
         final SlackDataStoreException exception = new SlackDataStoreException(cause);
@@ -55,6 +59,7 @@ public class SlackDataStoreExceptionTest extends UnitDsTestCase {
         assertEquals("Invalid argument", exception.getCause().getMessage());
     }
 
+    @Test
     public void test_exceptionCanBeThrown() {
         try {
             throw new SlackDataStoreException("Test exception");
@@ -63,18 +68,21 @@ public class SlackDataStoreExceptionTest extends UnitDsTestCase {
         }
     }
 
+    @Test
     public void test_exceptionWithNullMessage() {
         final SlackDataStoreException exception = new SlackDataStoreException((String) null);
         assertNotNull(exception);
         assertNull(exception.getMessage());
     }
 
+    @Test
     public void test_exceptionWithNullCause() {
         final SlackDataStoreException exception = new SlackDataStoreException((Throwable) null);
         assertNotNull(exception);
         assertNull(exception.getCause());
     }
 
+    @Test
     public void test_exceptionWithNullMessageAndCause() {
         final SlackDataStoreException exception = new SlackDataStoreException(null, null);
         assertNotNull(exception);
@@ -82,12 +90,14 @@ public class SlackDataStoreExceptionTest extends UnitDsTestCase {
         assertNull(exception.getCause());
     }
 
+    @Test
     public void test_exceptionInheritance() {
         final SlackDataStoreException exception = new SlackDataStoreException("Test");
         assertTrue(exception instanceof Exception);
         assertTrue(exception instanceof RuntimeException);
     }
 
+    @Test
     public void test_exceptionStackTrace() {
         final SlackDataStoreException exception = new SlackDataStoreException("Test with stack trace");
         final StackTraceElement[] stackTrace = exception.getStackTrace();

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreTest.java
@@ -145,8 +145,9 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     // Test setExtractorName method
     @Test
     public void test_setExtractorName() {
-        dataStore.setExtractorName("tikaExtractor");
         assertEquals("tikaExtractor", dataStore.extractorName);
+        dataStore.setExtractorName("customExtractor");
+        assertEquals("customExtractor", dataStore.extractorName);
     }
 
     // Test thread pool creation

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreTest.java
@@ -18,12 +18,7 @@ package org.codelibs.fess.ds.slack;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import org.codelibs.fess.app.service.FailureUrlService;
 import org.codelibs.fess.entity.DataStoreParams;
-import org.codelibs.fess.helper.CrawlerStatsHelper;
-import org.codelibs.fess.helper.SystemHelper;
-import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig;
-import org.codelibs.fess.opensearch.config.exentity.FailureUrl;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.ds.slack.UnitDsTestCase;
 
@@ -45,16 +40,6 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     public void setUp(TestInfo testInfo) throws Exception {
         super.setUp(testInfo);
         dataStore = new SlackDataStore();
-        ComponentUtil.register(new SystemHelper(), "systemHelper");
-        final CrawlerStatsHelper crawlerStatsHelper = new CrawlerStatsHelper();
-        crawlerStatsHelper.init();
-        ComponentUtil.register(crawlerStatsHelper, "crawlerStatsHelper");
-        ComponentUtil.register(new FailureUrlService() {
-            @Override
-            public FailureUrl store(final CrawlingConfig crawlingConfig, final String errorName, final String url, final Throwable e) {
-                return null;
-            }
-        }, FailureUrlService.class.getCanonicalName());
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/SlackDataStoreTest.java
@@ -15,23 +15,19 @@
  */
 package org.codelibs.fess.ds.slack;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.ds.callback.IndexUpdateCallback;
+import org.codelibs.fess.app.service.FailureUrlService;
 import org.codelibs.fess.entity.DataStoreParams;
-import org.codelibs.fess.mylasta.direction.FessConfig;
-import org.codelibs.fess.opensearch.config.exentity.DataConfig;
+import org.codelibs.fess.helper.CrawlerStatsHelper;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig;
+import org.codelibs.fess.opensearch.config.exentity.FailureUrl;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.ds.slack.UnitDsTestCase;
 
 public class SlackDataStoreTest extends UnitDsTestCase {
-
-    private static Logger logger = LogManager.getLogger(SlackDataStoreTest.class);
 
     public SlackDataStore dataStore;
 
@@ -49,6 +45,16 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     public void setUp(TestInfo testInfo) throws Exception {
         super.setUp(testInfo);
         dataStore = new SlackDataStore();
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final CrawlerStatsHelper crawlerStatsHelper = new CrawlerStatsHelper();
+        crawlerStatsHelper.init();
+        ComponentUtil.register(crawlerStatsHelper, "crawlerStatsHelper");
+        ComponentUtil.register(new FailureUrlService() {
+            @Override
+            public FailureUrl store(final CrawlingConfig crawlingConfig, final String errorName, final String url, final Throwable e) {
+                return null;
+            }
+        }, FailureUrlService.class.getCanonicalName());
     }
 
     @Override
@@ -57,56 +63,15 @@ public class SlackDataStoreTest extends UnitDsTestCase {
         super.tearDown(testInfo);
     }
 
-    public void test_storeData() {
-        // doStoreDataTest();
-    }
-
-    protected void doStoreDataTest() {
-
-        final DataConfig dataConfig = new DataConfig();
-        final IndexUpdateCallback callback = new IndexUpdateCallback() {
-            @Override
-            public void store(DataStoreParams paramMap, Map<String, Object> dataMap) {
-                logger.info("[{}.{}] dataMap = {}", getClass(), getName(), dataMap);
-            }
-
-            @Override
-            public long getExecuteTime() {
-                return 0;
-            }
-
-            @Override
-            public long getDocumentSize() {
-                return 0;
-            }
-
-            @Override
-            public void commit() {
-            }
-        };
-        final DataStoreParams paramMap = new DataStoreParams();
-        paramMap.put("token", "");
-        paramMap.put("channels", "");
-        final Map<String, String> scriptMap = new HashMap<>();
-        final Map<String, Object> defaultDataMap = new HashMap<>();
-
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        scriptMap.put(fessConfig.getIndexFieldTitle(), "message.user + \" #\" + message.channel");
-        scriptMap.put(fessConfig.getIndexFieldContent(), "message.text + \"\\n\" + message.attachments");
-        scriptMap.put(fessConfig.getIndexFieldCreated(), "message.timestamp");
-        scriptMap.put(fessConfig.getIndexFieldUrl(), "message.permalink");
-
-        dataStore.storeData(dataConfig, callback, paramMap, scriptMap, defaultDataMap);
-
-    }
-
     // Test getMaxFilesize method
+    @Test
     public void test_getMaxFilesize_defaultValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         final long maxFilesize = dataStore.getMaxFilesize(paramMap);
         assertEquals(10000000L, maxFilesize);
     }
 
+    @Test
     public void test_getMaxFilesize_validValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("max_filesize", "5000000");
@@ -114,6 +79,7 @@ public class SlackDataStoreTest extends UnitDsTestCase {
         assertEquals(5000000L, maxFilesize);
     }
 
+    @Test
     public void test_getMaxFilesize_invalidValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("max_filesize", "invalid");
@@ -122,12 +88,14 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     }
 
     // Test isIgnoreError method
+    @Test
     public void test_isIgnoreError_defaultValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         final boolean ignoreError = dataStore.isIgnoreError(paramMap);
         assertTrue(ignoreError);
     }
 
+    @Test
     public void test_isIgnoreError_trueValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("ignore_error", "true");
@@ -135,6 +103,7 @@ public class SlackDataStoreTest extends UnitDsTestCase {
         assertTrue(ignoreError);
     }
 
+    @Test
     public void test_isIgnoreError_falseValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("ignore_error", "false");
@@ -143,12 +112,14 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     }
 
     // Test isFileCrawl method
+    @Test
     public void test_isFileCrawl_defaultValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         final boolean fileCrawl = dataStore.isFileCrawl(paramMap);
         assertFalse(fileCrawl);
     }
 
+    @Test
     public void test_isFileCrawl_trueValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("file_crawl", "true");
@@ -156,6 +127,7 @@ public class SlackDataStoreTest extends UnitDsTestCase {
         assertTrue(fileCrawl);
     }
 
+    @Test
     public void test_isFileCrawl_falseValue() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("file_crawl", "false");
@@ -164,19 +136,21 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     }
 
     // Test getName method
+    @Test
     public void test_getName() {
         final String name = dataStore.getName();
         assertEquals("SlackDataStore", name);
     }
 
     // Test setExtractorName method
+    @Test
     public void test_setExtractorName() {
-        dataStore.setExtractorName("customExtractor");
-        // No direct getter to verify, but we can ensure no exception is thrown
-        assertNotNull(dataStore);
+        dataStore.setExtractorName("tikaExtractor");
+        assertEquals("tikaExtractor", dataStore.extractorName);
     }
 
     // Test thread pool creation
+    @Test
     public void test_newFixedThreadPool() {
         final java.util.concurrent.ExecutorService executorService = dataStore.newFixedThreadPool(2);
         assertNotNull(executorService);
@@ -184,12 +158,14 @@ public class SlackDataStoreTest extends UnitDsTestCase {
     }
 
     // Test newFixedThreadPool with different thread counts
+    @Test
     public void test_newFixedThreadPool_singleThread() {
         final java.util.concurrent.ExecutorService executorService = dataStore.newFixedThreadPool(1);
         assertNotNull(executorService);
         executorService.shutdown();
     }
 
+    @Test
     public void test_newFixedThreadPool_multipleThreads() {
         final java.util.concurrent.ExecutorService executorService = dataStore.newFixedThreadPool(5);
         assertNotNull(executorService);

--- a/src/test/java/org/codelibs/fess/ds/slack/TestIndexUpdateCallback.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/TestIndexUpdateCallback.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.ds.slack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.ds.callback.IndexUpdateCallback;
+import org.codelibs.fess.entity.DataStoreParams;
+
+/**
+ * Collects the documents handed to {@link IndexUpdateCallback#store} so that
+ * tests can assert on what would have been indexed.
+ */
+public class TestIndexUpdateCallback implements IndexUpdateCallback {
+
+    private final List<Map<String, Object>> dataMaps = new ArrayList<>();
+
+    @Override
+    public void store(final DataStoreParams paramMap, final Map<String, Object> dataMap) {
+        dataMaps.add(new HashMap<>(dataMap));
+    }
+
+    @Override
+    public long getExecuteTime() {
+        return 0;
+    }
+
+    @Override
+    public long getDocumentSize() {
+        return dataMaps.size();
+    }
+
+    @Override
+    public void commit() {
+        // nothing to do
+    }
+
+    /**
+     * Returns the collected documents in the order they were stored.
+     *
+     * @return the stored data maps
+     */
+    public List<Map<String, Object>> getDataMaps() {
+        return dataMaps;
+    }
+
+    /**
+     * Returns the number of collected documents.
+     *
+     * @return the number of stored data maps
+     */
+    public int size() {
+        return dataMaps.size();
+    }
+}

--- a/src/test/java/org/codelibs/fess/ds/slack/UnitDsTestCase.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/UnitDsTestCase.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.ds.slack;
 
+import org.codelibs.fess.ds.slack.api.Request;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
 import org.junit.jupiter.api.Assertions;
@@ -37,6 +38,11 @@ public abstract class UnitDsTestCase extends LastaFluteTestCase {
     @Override
     protected void tearDown(TestInfo testInfo) throws Exception {
         ComponentUtil.setFessConfig(null);
+        // Request.setEndpoint/resetEndpoint mutate process-wide static state (see
+        // Request's javadoc). Reset it here unconditionally so a subclass that
+        // forgets to call SlackApiMockServer#stop() (or fails before reaching it)
+        // cannot leave every later test class in this JVM pointed at a closed port.
+        Request.resetEndpoint();
         super.tearDown(testInfo);
     }
 

--- a/src/test/java/org/codelibs/fess/ds/slack/api/RequestEndpointTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/api/RequestEndpointTest.java
@@ -18,6 +18,13 @@ package org.codelibs.fess.ds.slack.api;
 import org.codelibs.fess.ds.slack.UnitDsTestCase;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Mutates {@link Request}'s process-wide static endpoint field, the same global
+ * {@link org.codelibs.fess.ds.slack.SlackApiMockServer} points at {@code Request.setEndpoint}
+ * during {@code start()}/{@code stop()}. Safe today only because surefire runs every test class
+ * in this module sequentially in one JVM; running test classes in parallel would let this race
+ * with any test using the mock server.
+ */
 public class RequestEndpointTest extends UnitDsTestCase {
 
     @Test

--- a/src/test/java/org/codelibs/fess/ds/slack/api/RequestEndpointTest.java
+++ b/src/test/java/org/codelibs/fess/ds/slack/api/RequestEndpointTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.ds.slack.api;
+
+import org.codelibs.fess.ds.slack.UnitDsTestCase;
+import org.junit.jupiter.api.Test;
+
+public class RequestEndpointTest extends UnitDsTestCase {
+
+    @Test
+    public void test_defaultEndpoint() {
+        Request.resetEndpoint();
+        assertEquals("https://slack.com/api/", Request.getEndpoint());
+    }
+
+    @Test
+    public void test_setEndpoint() {
+        try {
+            Request.setEndpoint("http://localhost:9999/api/");
+            assertEquals("http://localhost:9999/api/", Request.getEndpoint());
+        } finally {
+            Request.resetEndpoint();
+        }
+    }
+
+    @Test
+    public void test_resetEndpoint() {
+        Request.setEndpoint("http://localhost:9999/api/");
+        Request.resetEndpoint();
+        assertEquals("https://slack.com/api/", Request.getEndpoint());
+    }
+}


### PR DESCRIPTION
## Summary

The test suite in this plugin has never run. Before this branch:

```
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

The three test classes carried 46 `public void test_*` methods, none of which had `@Test`. The base class hierarchy is JUnit 5 — utflute 2.5.0's `PlainTestCase` declares `@BeforeEach`/`@AfterEach` — and the test classpath has only `junit-jupiter-engine:5.10.0` with no vintage engine, so JUnit Platform discovered nothing. CI runs `mvn -B package`, so it stayed green throughout.

This branch makes the suite execute (0 → 61 tests) and adds a mock Slack Web API server so that paging, `{"ok":false}` error bodies and HTTP 429 with `Retry-After` can be exercised without a live Slack workspace.

It is the first of several planned changes. Follow-up work depends on this harness, so it is deliberately scoped to test infrastructure: the only production change is one seam in `api/Request.java`.

## Enabling the suite

- Add `@org.junit.jupiter.api.Test` to every test method.
- Fix `assertEquals` argument order in `SlackClientTest`. The two-arg form comes from UTFlute's `PlainTestCase` and is `(expected, actual)`; the calls were written `(actual, expected)`. The comparison result is unchanged — failure messages were inverted.
- Remove `testProduction()`, `test_storeData()` and the twelve `do*Test()` helpers. Their bodies were empty or commented out, they required a live Slack workspace and token, and they were unreachable because their only caller was commented out. The mock server supersedes what they documented.
- Remove `test_setExtractorName()`'s original body, which asserted only `assertNotNull(dataStore)`, and replace it with an assertion that would fail against a no-op setter.
- Assert list sizes before the loops in `testConversationsList`, `testUsersList` and `testFilesList`. Each iterated `for (i = 0; i < list.size(); i++)`, so a Jackson mapping regression returning an empty list would have skipped the body and passed — `testUsersList` would have asserted nothing at all.

## The mock server

`SlackApiMockServer` is backed by the JDK's `com.sun.net.httpserver`, so no new dependency is introduced. Responses are queued per path and consumed in order.

Two design points worth review:

**The default response carries every list field empty**, not a bare `{"ok":true}`. `SlackClient.getUsers` calls `response.getMembers().forEach(...)` and then `response.getResponseMetadata().getNextCursor()` with no null checks; `getAllChannels` does the same; `getChannelFiles` calls `response.getPaging().getPage()`. Since the `SlackClient` constructor preloads users and channels unconditionally, a bare `{"ok":true}` throws NPE immediately. The javadoc explains this so the body is not "simplified" later. That null-intolerance is a real robustness gap, left for a follow-up rather than fixed here.

**The harness fails loudly rather than quietly.** `getQueuedCount`, `assertAllConsumed` and an opt-in strict mode (unscripted paths answer `503 {"ok":false,"error":"unscripted_request"}`) exist because the earlier design returned an empty success for every mistake a test author could make — enqueuing too few responses, enqueuing for a path the client constructor consumes, or enqueuing for a scalar endpoint the default cannot serve. For a harness meant to guard later bug fixes, a silent empty success is the wrong failure mode.

The class and `enqueue` javadoc both note that `users.list` and `conversations.list` are consumed once each by the `SlackClient` constructor, and `newClient(...)` accounts for that preload in one place.

## The production change

`Request`'s endpoint was a `static final` constant, so no test could redirect it. It is now a `volatile` field with `getEndpoint` / `setEndpoint` / `resetEndpoint`. Volatile because the data store calls the API from worker threads, so an override must be visible across them. `setEndpoint` rejects null and a value without a trailing slash. `UnitDsTestCase.tearDown` resets it unconditionally, so a test that forgets to stop its server cannot point every later test class at a closed port.

## Notes

- `SlackDataStoreTest` no longer registers `SystemHelper`, `CrawlerStatsHelper` or `FailureUrlService`. None of the 14 tests in that class touch them, and `SystemHelper.init()` cannot run against this module's `test_app.xml` — it resolves `systemProperties`, which the minimal test container does not define. A later change that actually exercises `storeData` should register them properly.
- `b5b1513`'s subject calls those registrations "required". They were not; `f957cd3` corrects the record in its body.
- `TestIndexUpdateCallback` is not yet used. It is included as harness infrastructure for the follow-up work, and its backing list is synchronized because `callback.store(...)` runs on worker threads.

## Verification

```
mvn -o -B clean package
```

```
[INFO] Tests run: 61, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`mvn -o license:check` is clean. `mvn -o clean javadoc:jar` is clean.
